### PR TITLE
feat: enchance for ibis-rw streaming features

### DIFF
--- a/sqlalchemy_risingwave/__init__.py
+++ b/sqlalchemy_risingwave/__init__.py
@@ -1,6 +1,6 @@
 from sqlalchemy.dialects import registry as _registry
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 _registry.register(
     "risingwave.psycopg2",


### PR DESCRIPTION

Ibis use sqlalchemy to access RW columns. However, sqlalchemy has not support sources. So in this PR, I work around this gap by considering sources as views.

Pump version to 1.0.1