### PR TITLE
feat: add release v1.0.x for sqlalchemy 1.4.x and fix get_view_names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     },
     packages=find_packages(include=["sqlalchemy_risingwave"]),
     include_package_data=True,
-    install_requires=["SQLAlchemy>=2.0,<2.1"],
+    install_requires=["SQLAlchemy>=1.4,<2.0"],
     zip_safe=False,
     # # Do not support dialects now.
     entry_points={

--- a/sqlalchemy_risingwave/__init__.py
+++ b/sqlalchemy_risingwave/__init__.py
@@ -1,6 +1,6 @@
 from sqlalchemy.dialects import registry as _registry
 
-__version__ = "1.1.1"
+__version__ = "1.0.2"
 
 _registry.register(
     "risingwave.psycopg2",

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -51,6 +51,18 @@ class SchemaTest(fixtures.TestBase):
             assert "v" in views
             assert "mv" in views
 
+            insp = inspect(testing.db)
+            views = insp.get_view_names(include = ("plain"))
+
+            assert len(views) == 1
+            assert "v" in views
+
+            insp = inspect(testing.db)
+            views = insp.get_view_names(include = ("materialized"))
+
+            assert len(views) == 1
+            assert "mv" in views
+
             conn.execute(text("DROP MATERIALIZED VIEW mv"))
             conn.execute(text("DROP VIEW v"))
             conn.execute(text("DROP TABLE t"))


### PR DESCRIPTION
sqlalchemy v1.4.x use different api from v2.0.x. So we should release v1.4.x for sqlalchemy 1.4.x and release v2.0.x for sqlalchemy 2.0.x.

use  sqlalchemy v1.4 get_view_names for in v1.4.x