### PR TITLE
feat: support tenant parameter for RisingWave Cloud connections

### DIFF
--- a/test/test_tenant.py
+++ b/test/test_tenant.py
@@ -1,0 +1,60 @@
+"""Tests for RisingWave Cloud tenant parameter handling."""
+
+from sqlalchemy import create_engine
+from sqlalchemy_risingwave.base import RisingWaveDialect
+
+
+class TestTenantParameter:
+    """Test cases for tenant parameter conversion."""
+
+    def test_tenant_parameter_converted_to_options(self):
+        """Test that tenant parameter is converted to --tenant option."""
+        dialect = RisingWaveDialect()
+        url = create_engine(
+            "risingwave://user:pass@host:4566/db?tenant=my-tenant"
+        ).url
+
+        cargs, cparams = dialect.create_connect_args(url)
+
+        assert "tenant" not in cparams
+        assert "options" in cparams
+        assert cparams["options"] == "--tenant=my-tenant"
+
+    def test_tenant_merged_with_existing_options(self):
+        """Test that tenant is merged with existing options parameter."""
+        dialect = RisingWaveDialect()
+        url = create_engine(
+            "risingwave://user:pass@host:4566/db?tenant=my-tenant&options=-c%20statement_timeout%3D30000"
+        ).url
+
+        cargs, cparams = dialect.create_connect_args(url)
+
+        assert "tenant" not in cparams
+        assert "options" in cparams
+        assert "--tenant=my-tenant" in cparams["options"]
+        assert "-c statement_timeout=30000" in cparams["options"]
+
+    def test_no_tenant_parameter(self):
+        """Test that connections without tenant work normally."""
+        dialect = RisingWaveDialect()
+        url = create_engine("risingwave://user:pass@host:4566/db").url
+
+        cargs, cparams = dialect.create_connect_args(url)
+
+        assert "tenant" not in cparams
+        # options should not be added if not present
+        assert cparams.get("options") is None or "--tenant" not in cparams.get(
+            "options", ""
+        )
+
+    def test_sslmode_preserved(self):
+        """Test that sslmode parameter is preserved alongside tenant."""
+        dialect = RisingWaveDialect()
+        url = create_engine(
+            "risingwave://user:pass@host:4566/db?sslmode=require&tenant=my-tenant"
+        ).url
+
+        cargs, cparams = dialect.create_connect_args(url)
+
+        assert cparams.get("sslmode") == "require"
+        assert cparams["options"] == "--tenant=my-tenant"


### PR DESCRIPTION
## Summary

- Add support for specifying the RisingWave Cloud tenant identifier as a `tenant` query parameter in the connection URL
- The dialect automatically converts `tenant=xxx` to `options=--tenant=xxx` format that RisingWave Cloud expects
- Includes unit tests for tenant parameter handling

## Motivation

Currently, connecting to RisingWave Cloud requires either:
1. Using the full hostname with tenant as subdomain: `rwc-xxx.host.risingwave.cloud`
2. Manually encoding the options parameter: `?options=--tenant%3Drwc-xxx`

This PR enables a more intuitive approach:
```python
risingwave://user:pass@host:4566/db?tenant=rwc-xxx
```

This is especially useful for libraries like [risingwave-py](https://github.com/risingwavelabs/risingwave-py) which use `extra_params` in connection configuration:
```python
RisingWaveConnOptions.from_connection_info(
    host="prod-aws-usea1-eks-a.risingwave.cloud",
    port=4566,
    user="oauth_default",
    password="<token>",
    database="dev",
    ssl="require",
    tenant="rwc-xxx",  # Now works!
)
```

See https://docs.risingwave.com/cloud/connection-errors for RisingWave Cloud connection methods.

## Test plan

- [x] Added unit tests for tenant parameter conversion
- [x] Tested connection to RisingWave Cloud with tenant parameter
- [x] Verified existing functionality still works (connections without tenant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)