### PR TITLE
Support SQLAlchemy 2.0 dialect APIs

### DIFF
--- a/sqlalchemy_risingwave/base.py
+++ b/sqlalchemy_risingwave/base.py
@@ -3,9 +3,9 @@ import re
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy import text
+from sqlalchemy.engine import reflection
 from sqlalchemy.util import warn
 
-from sqlalchemy import util
 import sqlalchemy.types as sqltypes
 import sqlalchemy.exc as exc
 
@@ -93,47 +93,85 @@ class RisingWaveDialect(PGDialect_psycopg2):
     def _get_server_version_info(self, conn):
         return (9, 5, 0)
 
+    @reflection.cache
     def get_table_names(self, conn, schema=None, **kw):
         sql = "SELECT tablename FROM pg_tables"
         if schema is not None:
             sql += f" WHERE schemaname = '{schema or self.default_schema_name}'"
         else:
-            sql += " WHERE schemaname <> 'rw_catalog' and schemaname <> 'pg_catalog' and schemaname <> 'information_schema'"
+            sql += (
+                " WHERE schemaname <> 'rw_catalog'"
+                " and schemaname <> 'pg_catalog'"
+                " and schemaname <> 'information_schema'"
+            )
         rows = conn.execute(text(sql))
         return [row.tablename for row in rows]
 
+    @reflection.cache
     def get_view_names(self, conn, schema=None, **kw):
         base_queries = [
             "SELECT viewname FROM pg_views",
-            "SELECT matviewname as viewname FROM pg_matviews",
         ]
         queries = []
         for sql in base_queries:
             if schema is not None:
                 sql += f" WHERE schemaname = '{schema or self.default_schema_name}'"
             else:
-                sql += " WHERE schemaname <> 'rw_catalog' and schemaname <> 'pg_catalog' and schemaname <> 'information_schema'"
+                sql += (
+                    " WHERE schemaname <> 'rw_catalog'"
+                    " and schemaname <> 'pg_catalog'"
+                    " and schemaname <> 'information_schema'"
+                )
             queries.append(sql)
         views = conn.execute(text(" UNION ".join(queries)))
 
         # As sqlalchmey has no support for Sources, we categorize as view temporarily.
-        source_sql = f"SELECT rw_catalog.rw_sources.name as source_name FROM rw_catalog.rw_sources JOIN rw_catalog.rw_schemas ON rw_catalog.rw_sources.schema_id = rw_catalog.rw_schemas.id"
+        source_sql = (
+            "SELECT rw_catalog.rw_sources.name as source_name"
+            " FROM rw_catalog.rw_sources"
+            " JOIN rw_catalog.rw_schemas"
+            " ON rw_catalog.rw_sources.schema_id = rw_catalog.rw_schemas.id"
+        )
         if schema is not None:
-            source_sql += f" WHERE rw_catalog.rw_schemas.name = '{schema or self.default_schema_name}'"
+            source_sql += (
+                " WHERE rw_catalog.rw_schemas.name = "
+                f"'{schema or self.default_schema_name}'"
+            )
         else:
-            source_sql += " WHERE rw_catalog.rw_schemas.name <> 'rw_catalog' and rw_catalog.rw_schemas.name <> 'pg_catalog' and rw_catalog.rw_schemas.name <> 'information_schema'"
+            source_sql += (
+                " WHERE rw_catalog.rw_schemas.name <> 'rw_catalog'"
+                " and rw_catalog.rw_schemas.name <> 'pg_catalog'"
+                " and rw_catalog.rw_schemas.name <> 'information_schema'"
+            )
         sources = conn.execute(text(source_sql))
 
         return [view.viewname for view in views] + [
             source.source_name for source in sources
         ]
 
-    def has_table(self, conn, table, schema=None, **kw):
-        return any(t == table for t in self.get_table_names(conn, schema=schema))
+    @reflection.cache
+    def get_materialized_view_names(self, conn, schema=None, **kw):
+        sql = "SELECT matviewname FROM pg_matviews"
+        if schema is not None:
+            sql += f" WHERE schemaname = '{schema or self.default_schema_name}'"
+        else:
+            sql += (
+                " WHERE schemaname <> 'rw_catalog'"
+                " and schemaname <> 'pg_catalog'"
+                " and schemaname <> 'information_schema'"
+            )
+        rows = conn.execute(text(sql))
+        return [row.matviewname for row in rows]
 
+    @reflection.cache
+    def has_table(self, conn, table_name, schema=None, **kw):
+        return any(t == table_name for t in self.get_table_names(conn, schema=schema))
+
+    @reflection.cache
     def get_columns(self, conn, table_name, schema=None, **kw):
         sql = (
-            "SELECT column_name, data_type FROM information_schema.columns WHERE "
+            "SELECT column_name, data_type, is_nullable, column_default"
+            " FROM information_schema.columns WHERE "
             "table_schema = :table_schema AND table_name = :table_name"
         )
         rows = conn.execute(
@@ -183,6 +221,10 @@ class RisingWaveDialect(PGDialect_psycopg2):
             column_info = dict(
                 name=name,
                 type=type_class,
+                nullable=row.is_nullable == "YES",
+                default=row.column_default,
+                autoincrement=False,
+                comment=None,
             )
 
             res.append(column_info)
@@ -214,6 +256,7 @@ class RisingWaveDialect(PGDialect_psycopg2):
             raise exc.NoSuchTableError(table_name)
         return table_oid
 
+    @reflection.cache
     def get_indexes(self, conn, table_name, schema=None, **kw):
         table_oid = self.get_table_oid(
             conn, table_name, schema, info_cache=kw.get("info_cache")
@@ -248,9 +291,106 @@ class RisingWaveDialect(PGDialect_psycopg2):
             )
         return res
 
+    def get_multi_columns(self, connection, schema, filter_names, scope, kind, **kw):
+        return self._default_multi_reflect(
+            self.get_columns,
+            connection,
+            kind=kind,
+            schema=schema,
+            filter_names=filter_names,
+            scope=scope,
+            **kw,
+        )
+
+    def get_multi_indexes(self, connection, schema, filter_names, scope, kind, **kw):
+        return self._default_multi_reflect(
+            self.get_indexes,
+            connection,
+            kind=kind,
+            schema=schema,
+            filter_names=filter_names,
+            scope=scope,
+            **kw,
+        )
+
+    def get_multi_pk_constraint(
+        self, connection, schema, filter_names, scope, kind, **kw
+    ):
+        return self._default_multi_reflect(
+            self.get_pk_constraint,
+            connection,
+            kind=kind,
+            schema=schema,
+            filter_names=filter_names,
+            scope=scope,
+            **kw,
+        )
+
+    def get_multi_foreign_keys(
+        self,
+        connection,
+        schema,
+        filter_names,
+        scope,
+        kind,
+        postgresql_ignore_search_path=False,
+        **kw,
+    ):
+        return self._default_multi_reflect(
+            self.get_foreign_keys,
+            connection,
+            kind=kind,
+            schema=schema,
+            filter_names=filter_names,
+            scope=scope,
+            postgresql_ignore_search_path=postgresql_ignore_search_path,
+            **kw,
+        )
+
+    def get_multi_unique_constraints(
+        self, connection, schema, filter_names, scope, kind, **kw
+    ):
+        return self._default_multi_reflect(
+            self.get_unique_constraints,
+            connection,
+            kind=kind,
+            schema=schema,
+            filter_names=filter_names,
+            scope=scope,
+            **kw,
+        )
+
+    def get_multi_check_constraints(
+        self, connection, schema, filter_names, scope, kind, **kw
+    ):
+        return self._default_multi_reflect(
+            self.get_check_constraints,
+            connection,
+            kind=kind,
+            schema=schema,
+            filter_names=filter_names,
+            scope=scope,
+            **kw,
+        )
+
+    def get_multi_table_comment(
+        self, connection, schema, filter_names, scope, kind, **kw
+    ):
+        return self._default_multi_reflect(
+            self.get_table_comment,
+            connection,
+            kind=kind,
+            schema=schema,
+            filter_names=filter_names,
+            scope=scope,
+            **kw,
+        )
+
+    @reflection.cache
     def get_foreign_keys_v1(self, conn, table_name, schema=None, **kw):
         return []
 
+    @reflection.cache
     def get_foreign_keys(
         self,
         connection,
@@ -261,13 +401,16 @@ class RisingWaveDialect(PGDialect_psycopg2):
     ):
         return []
 
+    @reflection.cache
     def get_pk_constraint(self, conn, table_name, schema=None, **kw):
         # TODO: Fill in real implementation to make get pk constraint work.
         return dict()
 
+    @reflection.cache
     def get_unique_constraints(self, conn, table_name, schema=None, **kw):
         return []
 
+    @reflection.cache
     def get_check_constraints(self, conn, table_name, schema=None, **kw):
         return []
 
@@ -278,7 +421,7 @@ class RisingWaveDialect(PGDialect_psycopg2):
         raise NotImplementedError
 
     def get_isolation_level(self, connection):
-        return {"default": "SERIALIZABLE", "supported": ["SERIALIZABLE"]}
+        return "SERIALIZABLE"
 
     def get_isolation_level_values(self, dbapi_conn):
         return (
@@ -288,9 +431,10 @@ class RisingWaveDialect(PGDialect_psycopg2):
             "REPEATABLE READ",
         )
 
+    @reflection.cache
     def get_table_comment(self, connection, table_name, schema=None, **kw):
         # TODO: Support table comment
-        return dict()
+        return {"text": None}
 
     def get_default_isolation_level(self, dbapi_conn):
         return self.get_isolation_level(dbapi_conn)

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -4,11 +4,12 @@
 # To add/update dependencies, update test-requirements.in (not the
 # generated test-requirements.txt) and run make update-requirements
 
-alembic
+# Keep the test lock compatible with the current Python 3.8/3.9 CI matrix.
+alembic<1.15
 asyncpg
 futures
 mock
 more-itertools
 psycopg2
 pytest
-sqlalchemy>=1.4,<2
+sqlalchemy>=2.0,<2.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,6 +6,8 @@ asyncpg==0.29.0
     # via -r test-requirements.in
 futures==3.0.5
     # via -r test-requirements.in
+greenlet==3.1.1
+    # via sqlalchemy
 iniconfig==2.0.0
     # via pytest
 mako==1.3.0
@@ -24,9 +26,11 @@ psycopg2==2.9.9
     # via -r test-requirements.in
 pytest==7.4.3
     # via -r test-requirements.in
-sqlalchemy==1.4.50
+sqlalchemy==2.0.44
     # via
     #   -r test-requirements.in
     #   alembic
 typing-extensions==4.9.0
-    # via alembic
+    # via
+    #   alembic
+    #   sqlalchemy

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -20,7 +20,7 @@ class SchemaTest(fixtures.TestBase):
         Table("users", self.meta, autoload_with=testing.db, schema="public")
 
     def test_has_table(self):
-        with testing.db.begin() as conn:
+        with testing.db.begin():
             insp = inspect(testing.db)
             assert insp.has_table(table_name="users", schema="public")
 
@@ -46,10 +46,11 @@ class SchemaTest(fixtures.TestBase):
 
             insp = inspect(testing.db)
             views = insp.get_view_names()
+            materialized_views = insp.get_materialized_view_names()
 
-            assert len(views) == 2
+            assert len(views) == 1
             assert "v" in views
-            assert "mv" in views
+            assert materialized_views == ["mv"]
 
             conn.execute(text("DROP MATERIALIZED VIEW mv"))
             conn.execute(text("DROP VIEW v"))

--- a/test/test_tenant.py
+++ b/test/test_tenant.py
@@ -24,7 +24,8 @@ class TestTenantParameter:
         """Test that tenant is merged with existing options parameter."""
         dialect = RisingWaveDialect()
         url = create_engine(
-            "risingwave://user:pass@host:4566/db?tenant=my-tenant&options=-c%20statement_timeout%3D30000"
+            "risingwave://user:pass@host:4566/db"
+            "?tenant=my-tenant&options=-c%20statement_timeout%3D30000"
         ).url
 
         cargs, cparams = dialect.create_connect_args(url)


### PR DESCRIPTION
## Summary

This is the first compatibility pass for SQLAlchemy 2.0+.

The package metadata already declares `SQLAlchemy>=2.0,<2.1`, but the test lockfile still pinned SQLAlchemy 1.4.50 and the dialect implementation still had several 1.x-shaped reflection APIs. This PR makes the declared support verifiable in CI and fixes the obvious SQLAlchemy 2.0 dialect API shape issues.

Changes:

- update test requirements from `sqlalchemy>=1.4,<2` to `>=2.0,<2.1` and regenerate `test-requirements.txt`
- add SQLAlchemy reflection cache decorators to dialect reflection methods, matching PostgreSQL dialect behavior
- rename `has_table(..., table, ...)` to the SQLAlchemy 2.0 signature `has_table(..., table_name, ...)`
- add `get_materialized_view_names()` and update the schema test to check materialized views via the SQLAlchemy 2.0 API
- make `get_columns()` return the stricter reflection fields expected by SQLAlchemy 2.x: `nullable`, `default`, `autoincrement`, `comment`
- make `get_isolation_level()` / `get_default_isolation_level()` return the isolation level string instead of the old dict shape
- make `get_table_comment()` return `{"text": None}`
- clean up existing lint issues in touched tests/imports

## Validation

Local validation without a running RisingWave server:

- `flake8 sqlalchemy_risingwave test`
- `python -m pytest -q --noconftest test/test_tenant.py`
- SQLAlchemy 2.0.51 smoke: dialect registration, tenant URL args, `has_table` signature, isolation-level shape, table-comment shape
- `git diff --check`

Full `pytest` requires a live RisingWave on `localhost:4566` because the SQLAlchemy testing plugin connects during pytest session start. GitHub Actions should cover that path via the existing RisingWave install step.

## Follow-ups

This PR does not claim full SQLAlchemy official suite compliance. Recommended next PRs:

1. implement real `has_table()` and PK/constraint reflection queries directly against RisingWave catalogs instead of list-and-filter / empty stubs
2. expand `_type_map` for current RisingWave types (`int256`, `struct`, `list`, etc.)
3. run and curate the SQLAlchemy dialect compliance suite, then refine `requirements.py` from the current CockroachDB-derived copy
