### PR TITLE
Modernize Python support matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,10 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
     keywords="SQLAlchemy RisingWave",
     project_urls={
@@ -36,6 +35,7 @@ setup(
     },
     packages=find_packages(include=["sqlalchemy_risingwave"]),
     include_package_data=True,
+    python_requires=">=3.10",
     install_requires=["SQLAlchemy>=2.0,<2.1"],
     zip_safe=False,
     # # Do not support dialects now.

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -4,8 +4,7 @@
 # To add/update dependencies, update test-requirements.in (not the
 # generated test-requirements.txt) and run make update-requirements
 
-# Keep the test lock compatible with the current Python 3.8/3.9 CI matrix.
-alembic<1.15
+alembic
 asyncpg
 futures
 mock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,36 +1,34 @@
-alembic==1.13.1
+alembic==1.18.4
     # via -r test-requirements.in
-async-timeout==4.0.3
-    # via asyncpg
-asyncpg==0.29.0
+asyncpg==0.31.0
     # via -r test-requirements.in
 futures==3.0.5
     # via -r test-requirements.in
-greenlet==3.1.1
-    # via sqlalchemy
-iniconfig==2.0.0
+iniconfig==2.3.0
     # via pytest
-mako==1.3.0
+mako==1.3.12
     # via alembic
-markupsafe==2.1.3
+markupsafe==3.0.3
     # via mako
-mock==5.1.0
+mock==5.2.0
     # via -r test-requirements.in
-more-itertools==10.1.0
+more-itertools==11.1.0
     # via -r test-requirements.in
-packaging==23.2
+packaging==26.2
     # via pytest
-pluggy==1.3.0
+pluggy==1.6.0
     # via pytest
-psycopg2==2.9.9
+psycopg2==2.9.12
     # via -r test-requirements.in
-pytest==7.4.3
+pygments==2.20.0
+    # via pytest
+pytest==9.1.0
     # via -r test-requirements.in
-sqlalchemy==2.0.44
+sqlalchemy==2.0.51
     # via
     #   -r test-requirements.in
     #   alembic
-typing-extensions==4.9.0
+typing-extensions==4.15.0
     # via
     #   alembic
     #   sqlalchemy


### PR DESCRIPTION
## Summary

Modernize the Python support matrix after SQLAlchemy 2.0 support landed in #41.

- drop Python 3.8 and 3.9 from the GitHub Actions test matrix
- add Python 3.13 to the test matrix
- update package classifiers accordingly
- add `python_requires=">=3.10"`
- remove the temporary `alembic<1.15` test constraint that existed only to keep Python 3.8/3.9 installable
- regenerate `test-requirements.txt` for the modern matrix

## Rationale

Python 3.8 and 3.9 are both past upstream EOL. Keeping them in CI forced old dependency pins and already blocked the normal SQLAlchemy 2.0 test lock refresh through Alembic's Python version requirement.

This PR keeps the support-policy change separate from #41's SQLAlchemy 2.0 dialect API fixes.

## Validation

Local validation:

- `flake8 sqlalchemy_risingwave test`
- `python -m pytest -q --noconftest test/test_tenant.py`
- `git diff --check`

Full integration validation should be covered by the PR GitHub Actions matrix against Python 3.10 / 3.11 / 3.12 / 3.13.
