### PR TITLE
Reflect primary key constraints

### DIFF
--- a/sqlalchemy_risingwave/base.py
+++ b/sqlalchemy_risingwave/base.py
@@ -403,8 +403,37 @@ class RisingWaveDialect(PGDialect_psycopg2):
 
     @reflection.cache
     def get_pk_constraint(self, conn, table_name, schema=None, **kw):
-        # TODO: Fill in real implementation to make get pk constraint work.
-        return dict()
+        sql = """
+            SELECT
+                tc.constraint_name,
+                kcu.column_name
+            FROM information_schema.table_constraints AS tc
+            JOIN information_schema.key_column_usage AS kcu
+              ON tc.constraint_catalog = kcu.constraint_catalog
+             AND tc.constraint_schema = kcu.constraint_schema
+             AND tc.constraint_name = kcu.constraint_name
+             AND tc.table_schema = kcu.table_schema
+             AND tc.table_name = kcu.table_name
+            WHERE tc.constraint_type = 'PRIMARY KEY'
+              AND tc.table_schema = :table_schema
+              AND tc.table_name = :table_name
+            ORDER BY kcu.ordinal_position
+        """
+        rows = conn.execute(
+            text(sql),
+            {
+                "table_schema": schema or self.default_schema_name,
+                "table_name": table_name,
+            },
+        ).fetchall()
+
+        if not rows:
+            return {"constrained_columns": [], "name": None}
+
+        return {
+            "constrained_columns": [row.column_name for row in rows],
+            "name": rows[0].constraint_name,
+        }
 
     @reflection.cache
     def get_unique_constraints(self, conn, table_name, schema=None, **kw):

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -38,6 +38,20 @@ class SchemaTest(fixtures.TestBase):
 
             conn.execute(text("DROP TABLE t"))
 
+    def test_get_pk_constraint(self):
+        insp = inspect(testing.db)
+        pk = insp.get_pk_constraint("users")
+
+        assert pk["constrained_columns"] == ["name"]
+        assert pk["name"] is not None
+
+    def test_reflected_primary_key_column(self):
+        reflected_meta = MetaData()
+        users = Table("users", reflected_meta, autoload_with=testing.db)
+
+        assert users.c.name.primary_key
+        assert [column.name for column in users.primary_key.columns] == ["name"]
+
     def test_get_view_names(self):
         with testing.db.begin() as conn:
             conn.execute(text("CREATE TABLE t (id1 INT, id2 INT, id3 INT)"))


### PR DESCRIPTION
## Summary
- implement get_pk_constraint using information_schema table_constraints/key_column_usage
- return SQLAlchemy's constrained_columns/name shape for tables with or without primary keys
- add real RisingWave-backed tests for inspector primary-key output and reflected Column.primary_key state

## Validation
- . /tmp/sqlalchemy-rw-venv/bin/activate && python -m py_compile sqlalchemy_risingwave/base.py test/test_schema.py
- . /tmp/sqlalchemy-rw-venv/bin/activate && flake8 sqlalchemy_risingwave test
- git diff --check

Closes #11