### PR TITLE
Improve reflected column type metadata

### DIFF
--- a/sqlalchemy_risingwave/base.py
+++ b/sqlalchemy_risingwave/base.py
@@ -25,6 +25,7 @@ _type_map = {
     "numeric": sqltypes.DECIMAL,  # DataType::Decimal
     "decimal": sqltypes.DECIMAL,  # DataType::Decimal
     "date": sqltypes.DATE,  # DataType::Date
+    "text": sqltypes.TEXT,
     "varchar": sqltypes.VARCHAR,  # DataType::Varchar
     "character varying": sqltypes.VARCHAR,  # DataType::Varchar
     "time": sqltypes.Time,  # DataType::Time
@@ -192,11 +193,15 @@ class RisingWaveDialect(PGDialect_psycopg2):
                 warn("Struct is not supported")
                 type_class = sqltypes.NULLTYPE
             else:
-                m = re.match(r"^([a-z ]+)((\[\])*)$", type_str)
+                m = re.match(
+                    r"^([a-z ]+)(?:\(([^)]*)\))?((\[\])*)$",
+                    type_str,
+                )
                 kwargs = {}
                 if m:
                     groups = m.groups()
                     type_name = groups[0]
+                    type_args = groups[1]
 
                     if type_name in _type_map:
                         data_type = _type_map[type_name]
@@ -205,13 +210,25 @@ class RisingWaveDialect(PGDialect_psycopg2):
 
                     if type_name == "timestamp with time zone":
                         kwargs["timezone"] = True
+                    if type_name in ("varchar", "character varying") and type_args:
+                        kwargs["length"] = int(type_args)
+                    if type_name in ("numeric", "decimal") and type_args:
+                        numeric_args = [
+                            int(arg.strip())
+                            for arg in type_args.split(",")
+                            if arg.strip()
+                        ]
+                        if len(numeric_args) >= 1:
+                            kwargs["precision"] = numeric_args[0]
+                        if len(numeric_args) >= 2:
+                            kwargs["scale"] = numeric_args[1]
                 else:
                     data_type = None
 
                 if data_type:
                     type_class = data_type(**kwargs)
-                    if len(groups) > 1:
-                        array_suffixs = re.findall(r"\[\]", groups[1])
+                    if groups[2]:
+                        array_suffixs = re.findall(r"\[\]", groups[2])
                         for i in range(0, len(array_suffixs)):
                             type_class = sqltypes.ARRAY(type_class)
                 else:

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -1,6 +1,7 @@
 from sqlalchemy import text
 from sqlalchemy import MetaData, Table, testing, inspect
 from sqlalchemy.testing import fixtures
+import sqlalchemy.types as sqltypes
 
 
 class SchemaTest(fixtures.TestBase):
@@ -51,6 +52,30 @@ class SchemaTest(fixtures.TestBase):
 
         assert users.c.name.primary_key
         assert [column.name for column in users.primary_key.columns] == ["name"]
+
+    def test_get_columns_reflects_text_and_alias_types(self):
+        with testing.db.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE TABLE reflected_types ("
+                    "txt TEXT,"
+                    "short_name VARCHAR,"
+                    "amount DECIMAL"
+                    ")"
+                )
+            )
+
+            insp = inspect(testing.db)
+            columns = {
+                column["name"]: column["type"]
+                for column in insp.get_columns("reflected_types")
+            }
+
+            assert isinstance(columns["txt"], sqltypes.VARCHAR)
+            assert isinstance(columns["short_name"], sqltypes.VARCHAR)
+            assert isinstance(columns["amount"], sqltypes.DECIMAL)
+
+            conn.execute(text("DROP TABLE reflected_types"))
 
     def test_get_view_names(self):
         with testing.db.begin() as conn:


### PR DESCRIPTION
## Summary
- map reflected TEXT if a catalog path emits it instead of returning NULLTYPE
- parse VARCHAR length and DECIMAL precision/scale when catalog strings include type arguments
- preserve existing array handling for parameterized base types
- add real RisingWave-backed reflection coverage for accepted TEXT, VARCHAR, and DECIMAL aliases

## Notes
- CI showed RisingWave v3.0 rejects `VARCHAR(12)` / `DECIMAL(10,2)` in `CREATE TABLE`, so the live catalog test only asserts currently accepted DDL forms. The parser still handles type arguments defensively for catalog strings from versions or paths that emit them.
- CI showed `TEXT` DDL is normalized by RisingWave v3.0 catalog to SQLAlchemy `VARCHAR`, so the live assertion follows that catalog behavior.
- CI also showed `CHAR` is not supported by RisingWave v3.0, so this PR intentionally does not claim CHAR reflection support.

## Validation
- `. /tmp/sqlalchemy-rw-venv/bin/activate && python -m py_compile sqlalchemy_risingwave/base.py test/test_schema.py`
- `. /tmp/sqlalchemy-rw-venv/bin/activate && flake8 sqlalchemy_risingwave test`
- `git diff --check`

Addresses #21 and partially addresses #9
