### PR TITLE
ci: add advisory SQLAlchemy compliance suite workflow

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,0 +1,97 @@
+name: SQLAlchemy compliance suite (baseline)
+
+# Phase 3 of the SQLAlchemy 2.0+ support effort: run the upstream
+# ``sqlalchemy.testing.suite`` against a real RisingWave instance and
+# record how many dialect-level conformance tests pass. The suite is
+# intentionally not required for PR merge yet — its purpose right now is
+# to surface the actual gap between "RisingWave-compatible" and "real
+# SQLAlchemy dialect compliance", so that requirements.py can be tuned
+# off measured behaviour rather than copy-pasted from CockroachDB.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - sqlalchemy_risingwave/**
+      - test-requirements.in
+      - test-requirements.txt
+      - .github/workflows/compliance.yml
+  workflow_dispatch:
+
+jobs:
+  compliance:
+    runs-on: ubuntu-latest
+    # Do not block PRs on compliance regressions yet — first we need a
+    # measured baseline, then we tighten requirements.py and re-enable
+    # individual feature flags. Until then the suite output is advisory.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            setup.py
+            test-requirements.txt
+
+      - name: Install Python dependencies
+        run: |
+          pip install -r test-requirements.txt
+          pip install .
+
+      - name: Install RisingWave
+        run: curl -L https://risingwave.com/sh | sh
+
+      - name: Start RisingWave
+        run: |
+          ./risingwave >stdout.log 2>stderr.log &
+          # Standalone mode takes a few seconds to accept psql connections.
+          sleep 5
+
+      - name: Run SQLAlchemy compliance suite
+        id: suite
+        continue-on-error: true
+        run: |
+          # The suite uses pytest's plugin discovery to pick up the
+          # ``Requirements`` class in sqlalchemy_risingwave.requirements;
+          # ``--dburi`` tells the suite which database to drive.
+          set -o pipefail
+          pytest --maxfail=0 -p no:cacheprovider \
+            --dburi 'risingwave://root@localhost:4566/dev' \
+            --requirements sqlalchemy_risingwave.requirements:Requirements \
+            --tb=line -q \
+            "$(python -c 'import sqlalchemy.testing.suite as s, os; print(os.path.dirname(s.__file__))')" \
+            2>&1 | tee compliance.log
+
+      - name: Summarize results
+        if: always()
+        run: |
+          if [ -f compliance.log ]; then
+            echo '## SQLAlchemy compliance suite summary' >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            tail -n 20 compliance.log >> "$GITHUB_STEP_SUMMARY" || true
+          else
+            echo 'compliance.log not produced' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload compliance log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compliance-log
+          path: compliance.log
+          if-no-files-found: warn
+
+      - name: Upload RisingWave logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: risingwave-logs
+          path: |
+            stdout.log
+            stderr.log
+          if-no-files-found: warn

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -56,15 +56,17 @@ jobs:
         id: suite
         continue-on-error: true
         run: |
-          # The suite uses pytest's plugin discovery to pick up the
-          # ``Requirements`` class in sqlalchemy_risingwave.requirements;
-          # ``--dburi`` tells the suite which database to drive.
+          # ``compliance/`` re-exports ``sqlalchemy.testing.suite`` and
+          # bootstraps the dialect registration; ``setup.cfg``'s ``[db]``
+          # and ``[sqla_testing]`` blocks pin the DB URI and Requirements
+          # class. The compliance directory is intentionally outside the
+          # default ``test/*test_*.py`` glob so the existing always-green
+          # smoke suite stays fast and merge-gating.
           set -o pipefail
-          pytest --maxfail=0 -p no:cacheprovider \
-            --dburi 'risingwave://root@localhost:4566/dev' \
-            --requirements sqlalchemy_risingwave.requirements:Requirements \
-            --tb=line -q \
-            "$(python -c 'import sqlalchemy.testing.suite as s, os; print(os.path.dirname(s.__file__))')" \
+          pytest --maxfail=0 -p no:cacheprovider --tb=line -q \
+            -o "python_files=*test_*.py" \
+            -o "addopts=" \
+            compliance/ \
             2>&1 | tee compliance.log
 
       - name: Summarize results

--- a/compliance/conftest.py
+++ b/compliance/conftest.py
@@ -1,0 +1,30 @@
+"""Conftest for the SQLAlchemy compliance suite directory.
+
+The compliance suite lives in its own directory so the existing happy-path
+``test/`` suite (always-green smoke tests for PR review) and the upstream
+dialect conformance suite (advisory, larger, currently expected to surface
+RisingWave streaming-semantics divergences) stay independently runnable.
+
+``setup.cfg``'s ``[db]`` and ``[sqla_testing]`` blocks plus the dialect
+registration in ``test/conftest.py`` are also needed here, so this file
+mirrors that minimal bootstrap before importing SQLAlchemy's pytest plugin.
+"""
+
+from sqlalchemy.dialects import registry
+import pytest
+
+registry.register(
+    "risingwave",
+    "sqlalchemy_risingwave.psycopg2",
+    "RisingWaveDialect_psycopg2",
+)
+
+registry.register(
+    "risingwave.psycopg2",
+    "sqlalchemy_risingwave.psycopg2",
+    "RisingWaveDialect_psycopg2",
+)
+
+pytest.register_assert_rewrite("sqlalchemy.testing.assertions")
+
+from sqlalchemy.testing.plugin.pytestplugin import *  # noqa: F401,F403

--- a/compliance/test_suite.py
+++ b/compliance/test_suite.py
@@ -1,0 +1,11 @@
+"""Re-export the upstream SQLAlchemy dialect compliance suite.
+
+Importing the suite here makes its hundreds of dialect-conformance tests
+discoverable under ``compliance/``. This directory is **not** part of the
+default ``test/*test_*.py`` glob in ``setup.cfg``; it is run explicitly by
+``.github/workflows/compliance.yml`` so the always-green smoke suite under
+``test/`` stays fast and merge-gating, and the compliance suite stays
+advisory until ``requirements.py`` has been tuned off measured behaviour.
+"""
+
+from sqlalchemy.testing.suite import *  # noqa: F401,F403

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,11 @@
 [tool:pytest]
 addopts= --tb native -v -r fxX --maxfail=25 -p no:warnings
 python_files=test/*test_*.py
+# Pin default discovery to ``test/`` so the always-green smoke suite is the
+# only thing the bare ``pytest`` invocation picks up. The compliance suite
+# under ``compliance/`` is opt-in via ``.github/workflows/compliance.yml``,
+# which passes the directory explicitly.
+testpaths=test
 
 [sqla_testing]
 requirement_cls = sqlalchemy_risingwave.requirements:Requirements

--- a/sqlalchemy_risingwave/requirements.py
+++ b/sqlalchemy_risingwave/requirements.py
@@ -35,6 +35,17 @@ class Requirements(SuiteRequirementsSQLA):
     # The autoincrement tests assume a predictable 1-based sequence.
     autoincrement_insert = exclusions.closed()
 
+    # RisingWave does not implement PostgreSQL's SERIAL / IDENTITY column
+    # autoincrement. The upstream compliance suite uses ``id SERIAL PRIMARY
+    # KEY`` as the default table-fixture shape, so leaving these flags open
+    # turns essentially every test in the suite into a CREATE TABLE failure:
+    # ``Not supported: Column type SERIAL is not supported``. Marking them
+    # closed lets ``sqlalchemy.testing.suite`` skip those tests cleanly
+    # instead of erroring during fixture setup.
+    autoincrement_without_sequence = exclusions.closed()
+    identity_columns = exclusions.closed()
+    identity_columns_standard = exclusions.closed()
+
     # The following features are off by default. We turn on as many as
     # we can without causing test failures.
     non_updating_cascade = exclusions.closed()


### PR DESCRIPTION
## Summary

Phase 3 of the SQLAlchemy 2.0+ support effort: actually measure how the dialect performs against the upstream `sqlalchemy.testing.suite` instead of relying on four hand-written reflection tests.

PR #41–#48 closed the obvious 2.0 dialect-API gaps and Superset-specific compatibility shims that came up in code review. This PR is what lets us move from *"works for the tests we wrote"* to a measured `X/Y passing` number that can be published honestly.

## What this does

- New workflow `.github/workflows/compliance.yml`:
  - Installs RisingWave (same `curl -L https://risingwave.com/sh | sh` path the existing CI uses).
  - Starts it standalone, waits a few seconds.
  - Runs the upstream `sqlalchemy.testing.suite` (re-exported under `compliance/test_suite.py`) against it.
  - Saves the suite log as an artifact (`compliance-log`) so triage can happen PR-by-PR.
  - Uploads RisingWave stdout/stderr on failure.
- New `compliance/` directory with its own conftest.py — kept outside `setup.cfg`'s `python_files=test/*test_*.py` and pinned via `testpaths=test` so the existing always-green smoke matrix is unaffected. Compliance is opt-in and advisory only (`continue-on-error: true`).
- First measured baseline (commit on this branch): **50 passed, 109 failed, 90 skipped, 1067 errors** out of 1317 collected tests. SERIAL-related errors in `ComponentReflectionTest` dominate (70%+).
- First requirements refinement: close `autoincrement_without_sequence` / `identity_columns` / `identity_columns_standard` so RW-incompatible SERIAL/IDENTITY tests skip instead of error during fixture setup.

## Baseline measured

```
109 failed, 50 passed, 90 skipped, 40 warnings, 1067 errors in 10.58s
```

Triage of the 1067 errors (top buckets by SQLA test class):
- `ComponentReflectionTest` — 749 errors, all driven by the shared SERIAL-PK fixture.
- `DifficultParametersTest` — 42.
- `FetchLimitOffsetTest` / `ExpandingBoundInTest` — 29 each.
- Remaining ~218 spread across DML / LIKE / unicode / DDL classes.

The SERIAL fixture failure is the single largest lever; the requirements.py flag change in this PR is the first half of fixing it (suite-level expectations), and a follow-up dialect-level DDL compiler change is needed to stop emitting `SERIAL` in the first place.

## Test plan

- [x] First CI run produces a `compliance-log` artifact with pass/fail counts (50/1317 baseline captured).
- [x] Triage the log: errors split into "RW DDL not supported (SERIAL)", "RW catalog gap", "RW streaming semantics", "real dialect bug" — see breakdown above.
- [x] First-round `requirements.py` refinement (this PR): close SERIAL/identity flags. Net effect on pass count is small because the fixture still emits SERIAL; the flags only gate test skip, not DDL.
- Follow-up PR β: dialect-level DDL compiler override to stop emitting `SERIAL` / `BIGSERIAL` / `SMALLSERIAL`. Expected effect: most of the 749 `ComponentReflectionTest` errors collapse into real test failures or passes.
- Follow-up PR γ: streaming-semantics flags (`insert_returning` immediate visibility, etc.).
- Follow-up PR δ: targeted dialect bugs from the remaining assertion failures.
- Once pass rate is high enough, drop `continue-on-error` and make compliance a real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
