### PR TITLE
compliance: rewrite SERIAL keywords in dialect DDL compiler (PR β)

### DIFF
--- a/sqlalchemy_risingwave/base.py
+++ b/sqlalchemy_risingwave/base.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from sqlalchemy.dialects.postgresql.base import PGDialect
+from sqlalchemy.dialects.postgresql.base import PGDDLCompiler, PGDialect
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy import text
 from sqlalchemy.engine import reflection
@@ -9,6 +9,38 @@ from sqlalchemy.util import warn
 
 import sqlalchemy.types as sqltypes
 import sqlalchemy.exc as exc
+
+
+class RisingWaveDDLCompiler(PGDDLCompiler):
+    """DDL compiler that rewrites PostgreSQL autoincrement keywords.
+
+    RisingWave's DDL parser rejects ``SERIAL`` / ``BIGSERIAL`` /
+    ``SMALLSERIAL`` with ``Not supported: Column type SERIAL is not
+    supported. HINT: Please remove the SERIAL column``. The PG parent
+    emits those keywords for any primary-key integer column that the ORM
+    flags as autoincrement, including the implicit autoincrement that
+    ``Table(... Column("id", Integer, primary_key=True) ...)`` picks up.
+
+    RisingWave does not provide PostgreSQL's per-row autoincrement
+    semantics anyway, so rewrite the keyword back to the underlying
+    integer type and let inserts supply explicit values. This makes the
+    upstream ``sqlalchemy.testing.suite`` fixtures actually create their
+    tables instead of erroring during setup, which is what surfaces the
+    real per-feature behaviour underneath.
+    """
+
+    _SERIAL_KEYWORDS = (
+        (" BIGSERIAL", " BIGINT"),
+        (" SMALLSERIAL", " SMALLINT"),
+        (" SERIAL", " INTEGER"),
+    )
+
+    def get_column_specification(self, column, **kwargs):
+        spec = super().get_column_specification(column, **kwargs)
+        for serial_kw, concrete_kw in self._SERIAL_KEYWORDS:
+            if serial_kw in spec:
+                spec = spec.replace(serial_kw, concrete_kw)
+        return spec
 
 _type_map = {
     "bool": sqltypes.BOOLEAN,  # DataType::Boolean
@@ -49,6 +81,7 @@ _warned_pg_cancel_probe = False
 
 class RisingWaveDialect(PGDialect_psycopg2):
     name = "risingwave"
+    ddl_compiler = RisingWaveDDLCompiler
 
     _PG_BACKEND_PID_SQL = re.compile(
         r"^\s*SELECT\s+pg_backend_pid\(\)\s*;?\s*$",

--- a/sqlalchemy_risingwave/base.py
+++ b/sqlalchemy_risingwave/base.py
@@ -3,7 +3,7 @@ import re
 
 from sqlalchemy.dialects.postgresql.base import PGDDLCompiler, PGDialect
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
-from sqlalchemy import text
+from sqlalchemy import schema, text
 from sqlalchemy.engine import reflection
 from sqlalchemy.util import warn
 
@@ -37,10 +37,38 @@ class RisingWaveDDLCompiler(PGDDLCompiler):
 
     def get_column_specification(self, column, **kwargs):
         spec = super().get_column_specification(column, **kwargs)
+        if not self._has_pg_serial_autoincrement(column):
+            return spec
+
         for serial_kw, concrete_kw in self._SERIAL_KEYWORDS:
             if serial_kw in spec:
                 spec = spec.replace(serial_kw, concrete_kw)
         return spec
+
+    def _has_pg_serial_autoincrement(self, column):
+        impl_type = column.type.dialect_impl(self.dialect)
+        if isinstance(impl_type, sqltypes.TypeDecorator):
+            impl_type = impl_type.impl
+
+        has_identity = (
+            column.identity is not None and self.dialect.supports_identity_columns
+        )
+        return (
+            column.primary_key
+            and column is column.table._autoincrement_column
+            and (
+                self.dialect.supports_smallserial
+                or not isinstance(impl_type, sqltypes.SmallInteger)
+            )
+            and not has_identity
+            and (
+                column.default is None
+                or (
+                    isinstance(column.default, schema.Sequence)
+                    and column.default.optional
+                )
+            )
+        )
 
 _type_map = {
     "bool": sqltypes.BOOLEAN,  # DataType::Boolean

--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -81,3 +81,25 @@ class UsageTest(fixtures.TestBase):
         assert inspector.has_table("sqlalchemy_rw_usage")
         columns = inspector.get_columns("sqlalchemy_rw_usage")
         assert [column["name"] for column in columns] == ["id", "name"]
+
+    def test_serial_keyword_rewritten_to_integer(self):
+        # When ``autoincrement`` is the SQLAlchemy default (i.e. an
+        # ``Integer`` primary key without ``autoincrement=False``), the
+        # PG parent compiler emits ``SERIAL``. RisingWave rejects that
+        # DDL; the dialect must rewrite the keyword to ``INTEGER`` so
+        # CREATE TABLE actually succeeds. Most of the upstream
+        # ``sqlalchemy.testing.suite`` fixtures rely on this implicit
+        # autoincrement shape, so this is the gate that lets the
+        # compliance suite progress past fixture setup.
+        metadata = MetaData()
+        Table(
+            "sqlalchemy_rw_usage",
+            metadata,
+            Column("id", Integer, primary_key=True),  # implicit autoincrement
+            Column("name", String),
+        )
+
+        metadata.create_all(testing.db)
+
+        inspector = inspect(testing.db)
+        assert inspector.has_table("sqlalchemy_rw_usage")

--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -9,8 +9,11 @@ from sqlalchemy import (
     select,
     text,
 )
+from sqlalchemy.schema import CreateTable
 from sqlalchemy import testing
 from sqlalchemy.testing import fixtures
+
+from sqlalchemy_risingwave.psycopg2 import RisingWaveDialect_psycopg2
 
 
 class UsageTest(fixtures.TestBase):
@@ -103,3 +106,18 @@ class UsageTest(fixtures.TestBase):
 
         inspector = inspect(testing.db)
         assert inspector.has_table("sqlalchemy_rw_usage")
+
+    def test_serial_rewrite_does_not_mutate_default_literals(self):
+        metadata = MetaData()
+        table = Table(
+            "sqlalchemy_rw_defaults",
+            metadata,
+            Column("note", String, server_default=text("' SERIAL'")),
+        )
+
+        ddl = str(
+            CreateTable(table).compile(dialect=RisingWaveDialect_psycopg2())
+        )
+
+        assert "DEFAULT ' SERIAL'" in ddl
+        assert "DEFAULT ' INTEGER'" not in ddl


### PR DESCRIPTION
## Summary

Phase 3, PR β: stop the dialect from emitting `SERIAL` / `BIGSERIAL` / `SMALLSERIAL` in CREATE TABLE so the compliance suite fixtures actually run.

## Background

The Phase-3 advisory compliance workflow (PR #47) measured a baseline of `50 passed, 109 failed, 90 skipped, 1067 errors` out of 1317 tests. Grouping the errors by SQLAlchemy test class:

| Class | Errors |
|---|---|
| `ComponentReflectionTest` | 749 |
| `DifficultParametersTest` | 42 |
| `FetchLimitOffsetTest` / `ExpandingBoundInTest` | 29 each |
| (others) | ~218 |

Every `ComponentReflectionTest` error has the same root cause: the shared class fixture does

```python
Table("users", metadata, Column("id", Integer, primary_key=True), ...)
```

and SQLAlchemy's default-autoincrement rule turns that into `id SERIAL NOT NULL`. RisingWave's DDL parser rejects that with `Not supported: Column type SERIAL is not supported. HINT: Please remove the SERIAL column`.

Closing the related `requirements.py` flags (also in PR #47) only gates test skips — the DDL still runs and still errors, because PG's `PGDDLCompiler.get_column_specification` emits the keyword unconditionally for autoincrement integer PKs.

## Changes

- New `RisingWaveDDLCompiler(PGDDLCompiler)`:
  - Overrides `get_column_specification`.
  - Calls `super().get_column_specification` and rewrites the emitted column spec to swap ` BIGSERIAL` → ` BIGINT`, ` SMALLSERIAL` → ` SMALLINT`, ` SERIAL` → ` INTEGER`.
  - The space prefix on the search strings means we only match the keyword that PG appends after the column name, not a substring of a user-supplied column name.
- `RisingWaveDialect.ddl_compiler = RisingWaveDDLCompiler` so the override is in effect for every `MetaData.create_all` / `Table(...).create(...)` path.
- New real-RW test `test_serial_keyword_rewritten_to_integer` exercises the default-autoincrement column shape and asserts the table actually exists after `metadata.create_all(testing.db)`.

## Semantic note

This does **not** add autoincrement semantics. RisingWave still does not generate per-row ids; inserts must continue to supply explicit values. The change is strictly about making the dialect emit DDL that RW's parser accepts.

## Expected effect on compliance baseline

The 749 `ComponentReflectionTest` errors are expected to collapse — those tests will now reach the assertion stage and either pass, fail with a real expectation mismatch, or skip cleanly via existing requirements flags. The next compliance run after merge will tell us the new baseline; that triage informs follow-up PRs γ / δ.

## Test plan

- [x] `pytest test/` → 15 passed (existing smoke matrix on Python 3.10/3.11/3.12/3.13)
- [x] `node --check` / `flake8` — n/a, Python only
- [x] New `test_serial_keyword_rewritten_to_integer` runs against the real RW that CI starts.
- [ ] After merge: compliance baseline rerun; report new pass/fail/error counts as part of follow-up PR γ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)