### PR TITLE
compliance: strip PG length/precision params from emitted types (PR γ)

### DIFF
--- a/sqlalchemy_risingwave/base.py
+++ b/sqlalchemy_risingwave/base.py
@@ -1,7 +1,11 @@
 import logging
 import re
 
-from sqlalchemy.dialects.postgresql.base import PGDDLCompiler, PGDialect
+from sqlalchemy.dialects.postgresql.base import (
+    PGDDLCompiler,
+    PGDialect,
+    PGTypeCompiler,
+)
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy import schema, text
 from sqlalchemy.engine import reflection
@@ -70,6 +74,49 @@ class RisingWaveDDLCompiler(PGDDLCompiler):
             )
         )
 
+class RisingWaveTypeCompiler(PGTypeCompiler):
+    """Type compiler that drops PostgreSQL-style length / precision arguments.
+
+    RisingWave's DDL parser rejects every PostgreSQL string and numeric type
+    that carries a parenthesised parameter:
+
+    - ``CHAR`` / ``CHAR(n)`` → ``Feature is not yet implemented: CHAR is not
+      supported, please use VARCHAR instead``.
+    - ``VARCHAR(n)`` → ``sql parser error: expected ',' or ')' after column
+      definition, found: '('``.
+    - ``NUMERIC(p, s)`` / ``DECIMAL(p, s)`` → ``unsupported data type:
+      NUMERIC(8,4)``.
+
+    The PostgreSQL parent emits those forms whenever the SQLAlchemy column
+    type carries ``.length`` / ``.precision`` / ``.scale``. That is the
+    default for ``String(50)`` / ``DECIMAL(10, 2)`` / ``Column(CHAR(3))``
+    fixtures the upstream compliance suite uses, so leaving the parent
+    behaviour intact makes hundreds of suite fixtures fail at CREATE TABLE.
+
+    Strip the parameters here. RisingWave does not enforce length / precision
+    caps anyway, so this is a DDL-acceptance fix rather than a semantic loss
+    — same shape as the SERIAL rewrite in ``RisingWaveDDLCompiler``.
+    """
+
+    def visit_CHAR(self, type_, **kw):
+        return "VARCHAR"
+
+    def visit_NCHAR(self, type_, **kw):
+        return "VARCHAR"
+
+    def visit_VARCHAR(self, type_, **kw):
+        return "VARCHAR"
+
+    def visit_NVARCHAR(self, type_, **kw):
+        return "VARCHAR"
+
+    def visit_NUMERIC(self, type_, **kw):
+        return "NUMERIC"
+
+    def visit_DECIMAL(self, type_, **kw):
+        return "DECIMAL"
+
+
 _type_map = {
     "bool": sqltypes.BOOLEAN,  # DataType::Boolean
     "boolean": sqltypes.BOOLEAN,  # DataType::Boolean
@@ -110,6 +157,7 @@ _warned_pg_cancel_probe = False
 class RisingWaveDialect(PGDialect_psycopg2):
     name = "risingwave"
     ddl_compiler = RisingWaveDDLCompiler
+    type_compiler = RisingWaveTypeCompiler
 
     _PG_BACKEND_PID_SQL = re.compile(
         r"^\s*SELECT\s+pg_backend_pid\(\)\s*;?\s*$",

--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -121,3 +121,58 @@ class UsageTest(fixtures.TestBase):
 
         assert "DEFAULT ' SERIAL'" in ddl
         assert "DEFAULT ' INTEGER'" not in ddl
+
+    def test_type_compiler_strips_pg_length_and_precision_parameters(self):
+        # RisingWave's DDL parser rejects every PG-style parameterised type:
+        # ``CHAR(n)`` / ``VARCHAR(n)`` / ``NUMERIC(p,s)`` / ``DECIMAL(p,s)``.
+        # The compliance suite's fixtures rely heavily on these shapes
+        # (``String(50)``, ``DECIMAL(10, 2)`` etc.), so any test using them
+        # used to fail during CREATE TABLE setup. Confirm at compile time
+        # that the dialect emits the bare keyword form RisingWave accepts.
+        from sqlalchemy import CHAR, DECIMAL, NUMERIC
+
+        metadata = MetaData()
+        table = Table(
+            "sqlalchemy_rw_type_params",
+            metadata,
+            Column("varchar_sized", String(50)),
+            Column("char_sized", CHAR(3)),
+            Column("numeric_sized", NUMERIC(10, 2)),
+            Column("decimal_sized", DECIMAL(8, 4)),
+            Column("varchar_default", String),
+        )
+
+        ddl = str(
+            CreateTable(table).compile(dialect=RisingWaveDialect_psycopg2())
+        )
+
+        for forbidden in ("VARCHAR(50)", "CHAR(3)", "NUMERIC(10, 2)", "DECIMAL(8, 4)"):
+            assert forbidden not in ddl, (
+                f"emitted {forbidden!r}, which RisingWave's DDL parser rejects"
+            )
+        # CHAR is rewritten to VARCHAR per the RisingWave hint message, not
+        # carried through unchanged. Confirm both the bare VARCHAR and the
+        # rewrite of CHAR are present.
+        assert ddl.count("VARCHAR") >= 3
+        assert "CHAR" not in ddl.replace("VARCHAR", "")
+        assert "NUMERIC" in ddl
+        assert "DECIMAL" in ddl
+
+    def test_create_table_with_parameterized_pg_types_runs_on_risingwave(self):
+        metadata = MetaData()
+        Table(
+            "sqlalchemy_rw_usage",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("varchar_sized", String(50)),
+            Column("name", String),
+        )
+
+        # Real RisingWave round trip: with the type-compiler override the
+        # emitted DDL must actually be runnable. Before this change the same
+        # table definition fails with ``expected ',' or ')' after column
+        # definition, found: '('``.
+        metadata.create_all(testing.db)
+
+        inspector = inspect(testing.db)
+        assert inspector.has_table("sqlalchemy_rw_usage")


### PR DESCRIPTION
## Summary

Phase 3, PR γ: stop emitting parameterised PG-style type forms (`CHAR(n)` / `VARCHAR(n)` / `NUMERIC(p, s)` / `DECIMAL(p, s)`) that RisingWave's DDL parser rejects.

## Background

After PR #49 (β) merged, the new compliance baseline is `55 passed, 181 failed, 108 skipped, 973 errors`. Grouping the remaining 973 errors by RisingWave's rejection message:

| Rejection | Count | Trigger |
|---|---|---|
| `CHAR is not supported, please use VARCHAR instead` | ~750 | emits `CHAR(n)` |
| `expected ',' or ')' after column definition, found: '('` | ~250 | emits `VARCHAR(n)` / `NUMERIC(p,s)` / `DECIMAL(p,s)` |
| `unsupported data type: UUID` | 14 | emits `UUID` (PR δ scope, Codex) |
| `unsupported data type: NUMERIC(8,4)` | 12 | (overlaps the parameterised-numeric bucket above) |
| `expected an object type after CREATE, found: TYPE` (ENUM) | 14 | emits `CREATE TYPE` (PR δ scope) |
| `table constraint "FOREIGN KEY ..."` | 10 | (PR δ scope) |

CHAR + parameterised string/numeric = ~1000 of the remaining 973 errors — the dominant lever for this PR.

## Changes

- New `RisingWaveTypeCompiler(PGTypeCompiler)` (in `sqlalchemy_risingwave/base.py`):
  - `visit_CHAR` / `visit_NCHAR` → `"VARCHAR"` (RW's own hint).
  - `visit_VARCHAR` / `visit_NVARCHAR` → `"VARCHAR"` (drop length).
  - `visit_NUMERIC` → `"NUMERIC"` (drop precision/scale).
  - `visit_DECIMAL` → `"DECIMAL"` (drop precision/scale).
- `RisingWaveDialect.type_compiler = RisingWaveTypeCompiler` to wire it through.

Compile sanity check:

```
CREATE TABLE t (
    a VARCHAR,    -- String(50)
    b VARCHAR,    -- CHAR(3)
    c NUMERIC,    -- NUMERIC(10, 2)
    d DECIMAL,    -- DECIMAL(8, 4)
    e VARCHAR     -- String (no length)
)
```

## Semantic note

This does **not** add length / precision enforcement; RisingWave doesn't enforce those caps anyway. The change is strictly about emitting DDL that RisingWave's parser accepts, same shape as PR #49's SERIAL rewrite.

## Test plan

- [x] Compile-level test `test_type_compiler_strips_pg_length_and_precision_parameters` locks the keyword rewrite at the dialect level.
- [x] Real-RW test `test_create_table_with_parameterized_pg_types_runs_on_risingwave` exercises `CREATE TABLE` with `String(50)` against the CI's RisingWave instance. Before this PR the same DDL fails with the parser error above.
- [ ] After merge: rerun compliance baseline; report new pass/fail/error counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)