### PR TITLE
compliance: skip constraint-heavy upstream fixtures

### DIFF
--- a/compliance/conftest.py
+++ b/compliance/conftest.py
@@ -28,3 +28,32 @@ registry.register(
 pytest.register_assert_rewrite("sqlalchemy.testing.assertions")
 
 from sqlalchemy.testing.plugin.pytestplugin import *  # noqa: F401,F403
+from sqlalchemy.testing.plugin.pytestplugin import (
+    pytest_collection_modifyitems as _sqla_pytest_collection_modifyitems,
+)
+
+
+_UNSUPPORTED_CONSTRAINT_FIXTURE_CLASSES = {
+    "ComponentReflectionTest",
+    "QuotedNameArgumentTest",
+    "CompositeKeyReflectionTest",
+}
+
+
+def pytest_collection_modifyitems(session, config, items):
+    _sqla_pytest_collection_modifyitems(session, config, items)
+
+    skip_constraint_fixtures = pytest.mark.skip(
+        reason=(
+            "RisingWave does not support table-level CHECK / UNIQUE / FK "
+            "constraints. These upstream suite classes require those "
+            "constraints in class-level fixtures, so the advisory compliance "
+            "run skips them instead of silently stripping user constraints."
+        )
+    )
+    for item in items:
+        if any(
+            item.nodeid.startswith(f"compliance/test_suite.py::{class_name}_")
+            for class_name in _UNSUPPORTED_CONSTRAINT_FIXTURE_CLASSES
+        ):
+            item.add_marker(skip_constraint_fixtures)

--- a/sqlalchemy_risingwave/requirements.py
+++ b/sqlalchemy_risingwave/requirements.py
@@ -27,6 +27,7 @@ class Requirements(SuiteRequirementsSQLA):
     cross_schema_fk_reflection = exclusions.closed()
     self_referential_foreign_keys = exclusions.closed()
     foreign_key_constraint_reflection = exclusions.closed()
+    unique_constraint_reflection = exclusions.closed()
 
     # We don't do implicit casts.
     date_coerces_from_datetime = exclusions.closed()

--- a/test/test_usage.py
+++ b/test/test_usage.py
@@ -220,4 +220,5 @@ class UsageTest(fixtures.TestBase):
         assert not requirements.foreign_key_ddl.enabled
         assert not requirements.self_referential_foreign_keys.enabled
         assert not requirements.foreign_key_constraint_reflection.enabled
+        assert not requirements.unique_constraint_reflection.enabled
         assert not requirements.uuid_data_type.enabled


### PR DESCRIPTION
## Summary

Phase 3 follow-up: keep user DDL semantics honest while making the advisory SQLAlchemy compliance run stop erroring on upstream fixture classes that require unsupported table-level constraints.

## Background

After PR #51, the compliance baseline is:

```
282 failed, 90 passed, 171 skipped, 774 errors
```

The largest remaining error bucket is still `ComponentReflectionTest` (749 errors), but the failure reason has changed. The earlier syntax/type blockers are gone; the shared upstream fixture now fails because it requires table-level constraints that RisingWave does not support:

```sql
CREATE TABLE users (
    user_id INTEGER NOT NULL,
    test1 VARCHAR NOT NULL,
    test2 FLOAT NOT NULL,
    parent_user_id INTEGER,
    PRIMARY KEY (user_id),
    CONSTRAINT zz_test2_gt_zero CHECK (test2 > 0),
    CHECK (test2 <= 1000)
)
```

RisingWave rejects this with:

```
Feature is not yet implemented: table constraint "CONSTRAINT zz_test2_gt_zero CHECK (test2 > 0)"
```

`QuotedNameArgumentTest` and `CompositeKeyReflectionTest` have the same fixture-level issue through UNIQUE / CHECK / FK constraints.

## Why skip instead of stripping constraints

For SERIAL / VARCHAR length / UUID / ENUM, the previous PRs were DDL-acceptance rewrites for syntax or native feature declarations that RisingWave does not enforce anyway.

CHECK / UNIQUE / FK are different: they encode user invariants. Silently stripping them in the dialect would make `CREATE TABLE` succeed while dropping validation/enforcement. That is unsafe.

So this PR **does not change user DDL emission**. User-authored CHECK / UNIQUE / FK still reaches RisingWave and fails honestly if unsupported. This PR only marks known unsupported upstream compliance fixture classes as skipped inside the advisory compliance harness.

## Changes

- `compliance/conftest.py` wraps SQLAlchemy's own `pytest_collection_modifyitems` hook and then marks these upstream suite classes skipped:
  - `ComponentReflectionTest`
  - `QuotedNameArgumentTest`
  - `CompositeKeyReflectionTest`
- `requirements.py` closes `unique_constraint_reflection`, matching the already-closed FK and CHECK expectations.
- Existing requirements smoke test now asserts `unique_constraint_reflection` is closed too.

## Test plan

- `python3 -m py_compile compliance/conftest.py`
- `git diff --check`
- CI integration matrix and advisory compliance suite will rerun on the PR.
