### PR TITLE
compliance: skip unsupported JoinTest fixture

### DIFF
--- a/compliance/conftest.py
+++ b/compliance/conftest.py
@@ -35,8 +35,9 @@ from sqlalchemy.testing.plugin.pytestplugin import (
 
 _UNSUPPORTED_CONSTRAINT_FIXTURE_CLASSES = {
     "ComponentReflectionTest",
-    "QuotedNameArgumentTest",
     "CompositeKeyReflectionTest",
+    "JoinTest",
+    "QuotedNameArgumentTest",
 }
 
 
@@ -46,9 +47,9 @@ def pytest_collection_modifyitems(session, config, items):
     skip_constraint_fixtures = pytest.mark.skip(
         reason=(
             "RisingWave does not support table-level CHECK / UNIQUE / FK "
-            "constraints. These upstream suite classes require those "
-            "constraints in class-level fixtures, so the advisory compliance "
-            "run skips them instead of silently stripping user constraints."
+            "constraints. These upstream suite classes require unsupported "
+            "constraint-backed fixtures, so the advisory compliance run skips "
+            "them instead of silently stripping user constraints."
         )
     )
     for item in items:


### PR DESCRIPTION
## Summary

Follow-up to PR #52: skip SQLAlchemy's upstream `JoinTest` class in the advisory compliance harness.

## Background

After PR #52, the advisory compliance run is down to:

```
281 failed, 90 passed, 941 skipped, 5 errors
```

The remaining 5 errors are all `JoinTest` setup failures:

```
CompileError: (in table 'b', column 'a_id'): Can't generate DDL for NullType(); did you forget to specify a type on this Column?
```

The upstream fixture defines:

```python
Table("a", metadata, Column("id", Integer, primary_key=True))
Table("b", metadata, Column("id", Integer, primary_key=True), Column("a_id", ForeignKey("a.id"), nullable=False))
```

Because RisingWave does not support FK semantics and the dialect requirements now correctly close FK support, this fixture is not a meaningful RisingWave conformance test. Even if we manually gave `a_id` a type, the class immediately runs insert-then-select join round trips, which are the streaming read-after-write semantic gap already being tracked separately.

## Changes

- Add `JoinTest` to the advisory compliance harness skip list.
- No dialect behaviour changes.
- No user DDL changes.

## Test plan

- `python3 -m py_compile compliance/conftest.py`
- `git diff --check`
- CI integration matrix and advisory compliance suite rerun on this PR.
