### PR TITLE
ci: run compliance workflow for harness changes

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -12,7 +12,10 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - compliance/**
       - sqlalchemy_risingwave/**
+      - setup.cfg
+      - setup.py
       - test-requirements.in
       - test-requirements.txt
       - .github/workflows/compliance.yml


### PR DESCRIPTION
## Summary
- include `compliance/**` in the advisory compliance workflow path filter
- also trigger it when `setup.cfg` / `setup.py` changes, because those files configure pytest and package install behavior

## Why
PR #53 only ran the normal integration workflow because it changed `compliance/conftest.py`, which was not included in the compliance workflow path filter. That left the expected post-JoinTest baseline unverified.

## Validation
- `git diff --check`

After this merges, we should manually dispatch the compliance workflow on `main` (or make a small compliance-touch PR) to confirm the #53 baseline.