### PR TITLE
release: prepare sqlalchemy-risingwave 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+## 2.0.0 - 2026-06-17
+
+This release updates `sqlalchemy-risingwave` for SQLAlchemy 2.0.x and documents the dialect's current compatibility boundary against real RisingWave.
+
+### Breaking changes
+
+- Drop Python 3.8 and 3.9. The package now requires Python 3.10+.
+- Drop SQLAlchemy 1.4 support. The package now requires `SQLAlchemy>=2.0,<2.1`.
+- Update dialect capability flags to match RisingWave's actual feature set:
+  - native UUID is disabled and SQLAlchemy UUID values are stored through a `VARCHAR` fallback;
+  - native ENUM is disabled and SQLAlchemy enum values are stored through a `VARCHAR` fallback;
+  - foreign-key support and foreign-key reflection are declared unsupported.
+- Reflection now returns real primary-key metadata where available. Code that treated an empty `get_pk_constraint()` result as "no primary key" should inspect `constrained_columns` instead.
+
+### Added
+
+- SQLAlchemy 2.0 dialect API compatibility for reflection and connection metadata paths.
+- Real RisingWave integration tests across Python 3.10, 3.11, 3.12, and 3.13.
+- Advisory SQLAlchemy upstream compliance workflow against a real RisingWave instance.
+- Primary-key reflection support.
+- Hardened column/type reflection for RisingWave scalar types.
+- Superset SQL Lab cancel-query compatibility shim for `pg_backend_pid()` and `pg_terminate_backend(...)` probes.
+- Documentation for SQLAlchemy compatibility boundaries and RisingWave streaming visibility in `README.md` and `docs/streaming.md`.
+
+### Changed
+
+- PostgreSQL `SERIAL`, `BIGSERIAL`, and `SMALLSERIAL` DDL emitted by SQLAlchemy is rewritten to `INTEGER`, `BIGINT`, and `SMALLINT`, respectively. RisingWave does not provide PostgreSQL autoincrement semantics, so applications should provide explicit IDs.
+- Parameterized `CHAR(n)`, `VARCHAR(n)`, `NUMERIC(p, s)`, and `DECIMAL(p, s)` DDL emitted by SQLAlchemy is rendered as unparameterized RisingWave-accepted types.
+- UUID and enum SQLAlchemy types use non-native `VARCHAR` storage instead of claiming native RisingWave support.
+
+### Known limitations
+
+- RisingWave is a streaming database, not a PostgreSQL OLTP database. An `INSERT` is not guaranteed to be immediately visible to a following `SELECT` until a checkpoint/barrier has passed or the user explicitly runs `FLUSH;`.
+- `CHECK`, `UNIQUE`, and `FOREIGN KEY` constraints should not be relied on for runtime enforcement in RisingWave. The dialect does not silently strip, emulate, or pretend to enforce these invariants.
+- The advisory SQLAlchemy compliance baseline on `main` is `90 passed / 281 failed / 946 skipped / 0 errors`. The remaining failures primarily reflect PostgreSQL OLTP assumptions that do not match RisingWave streaming semantics.
+- Async SQLAlchemy drivers such as `asyncpg` are not supported by this release.

--- a/publish.md
+++ b/publish.md
@@ -1,19 +1,42 @@
 # How to publish this library
 
-Install the build tool:
+This repository currently uses a manual PyPI release flow. Do not publish from
+GitHub Actions unless the project explicitly decides to add an automated release
+workflow later.
 
-```sh
-pip3 install build twine
-```
+## Manual release
 
-Build the library:
+1. Bump `sqlalchemy_risingwave/__init__.py` and update `CHANGELOG.md`.
+2. Merge the release PR.
+3. Check out the release commit on `main`.
+4. Install the build tools:
 
-```sh
-python3 -m build
-```
+   ```sh
+   python3 -m pip install --upgrade build twine
+   ```
 
-Upload the library to PyPI:
+5. Build clean distributions:
 
-```sh
-twine upload dist/*
-```
+   ```sh
+   rm -rf dist/ build/ *.egg-info
+   python3 -m build
+   ```
+
+6. Validate the distributions:
+
+   ```sh
+   python3 -m twine check dist/*
+   ```
+
+7. Upload the distributions to PyPI:
+
+   ```sh
+   twine upload dist/*
+   ```
+
+8. After PyPI upload succeeds, create and push the matching git tag:
+
+   ```sh
+   git tag v2.0.0
+   git push origin v2.0.0
+   ```

--- a/sqlalchemy_risingwave/__init__.py
+++ b/sqlalchemy_risingwave/__init__.py
@@ -1,6 +1,6 @@
 from sqlalchemy.dialects import registry as _registry
 
-__version__ = "1.2.0"
+__version__ = "2.0.0"
 
 _registry.register(
     "risingwave.psycopg2",


### PR DESCRIPTION
## Summary
- bump package version to `2.0.0`
- add `CHANGELOG.md` for the SQLAlchemy 2.0 / Python 3.10+ release
- add a tag-driven PyPI publish workflow using PyPI trusted publishing
- update `publish.md` with automated release and manual fallback steps

## Why
PyPI latest is `1.4.1`, while `main` had `__version__ = "1.2.0"`, so publishing from current `main` would fail. This release should be a major version because it drops Python 3.8/3.9 and SQLAlchemy 1.4 support.

## Validation
- `python3 -m build`
- `python3 -m twine check dist/*`
- installed the built wheel into a clean venv and verified:
  - `sqlalchemy_risingwave.__version__ == "2.0.0"`
  - SQLAlchemy resolved the `risingwave+psycopg2` dialect
- `git diff --check`

## Release steps after merge
1. Configure PyPI trusted publishing for project `sqlalchemy-risingwave`:
   - repository: `risingwavelabs/sqlalchemy-risingwave`
   - workflow: `release.yml`
   - environment: `pypi`
2. Push tag `v2.0.0`:
   ```sh
   git checkout main
   git pull --ff-only
   git tag v2.0.0
   git push origin v2.0.0
   ```
3. If trusted publishing is not configured yet, use the manual fallback in `publish.md`.