### PR TITLE
feat: async psycopg3 dialect (PR β of #57)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,11 @@ python_files=test/*test_*.py
 # under ``compliance/`` is opt-in via ``.github/workflows/compliance.yml``,
 # which passes the directory explicitly.
 testpaths=test
+# pytest-asyncio in strict mode requires every ``async def`` test to be
+# explicitly marked; pair that with the function-scoped event loop default
+# so each async test gets its own loop and engines never leak across tests.
+asyncio_mode=strict
+asyncio_default_fixture_loop_scope=function
 
 [sqla_testing]
 requirement_cls = sqlalchemy_risingwave.requirements:Requirements

--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,10 @@ setup(
     install_requires=["SQLAlchemy>=2.0,<2.1"],
     extras_require={
         # psycopg3 is the upstream-recommended PostgreSQL driver and the
-        # path used by ``risingwave+psycopg://`` synchronous engines. The
-        # asynchronous dialect that lets applications opt into
-        # ``create_async_engine`` for RisingWave is tracked separately in
-        # issue #57 and is not part of this release. ``psycopg`` imports
-        # lazily, so this dependency stays optional — existing
-        # psycopg2-only users are unaffected.
+        # path used by ``risingwave+psycopg://`` URLs for both sync
+        # ``create_engine`` and async ``create_async_engine`` engines.
+        # ``psycopg`` imports lazily, so this dependency stays optional —
+        # existing psycopg2-only users are unaffected.
         "psycopg3": ["psycopg[binary]>=3.1"],
     },
     zip_safe=False,

--- a/sqlalchemy_risingwave/__init__.py
+++ b/sqlalchemy_risingwave/__init__.py
@@ -8,18 +8,21 @@ _registry.register(
     "RisingWaveDialect_psycopg2",
 )
 
-# psycopg3 driver, synchronous only in this release.
-# ``create_engine("risingwave+psycopg://...")`` is supported.
-# ``create_async_engine("risingwave+psycopg://...")`` is intentionally
-# rejected at the dialect layer because SQLAlchemy's upstream
-# ``PGDialect_psycopg.get_async_dialect_cls`` returns an async class with
-# no RisingWave overrides; the async dialect is tracked in
-# https://github.com/risingwavelabs/sqlalchemy-risingwave/issues/57.
+# psycopg3 driver, synchronous and asynchronous.
+# ``create_engine("risingwave+psycopg://...")`` resolves to the sync
+# ``RisingWaveDialect_psycopg`` class, while
+# ``create_async_engine("risingwave+psycopg://...")`` is routed to the
+# async ``RisingWaveDialect_psycopg_async`` class via the sync class's
+# ``get_async_dialect_cls`` override so both paths inherit the
+# ``_RisingWaveCommon`` mixin instead of falling back to upstream
+# ``PGDialectAsync_psycopg``.
 _registry.register(
     "risingwave.psycopg",
     "sqlalchemy_risingwave.psycopg",
     "RisingWaveDialect_psycopg",
 )
 
-# asyncpg driver is not implemented; see the same issue #57 for the
-# async support roadmap.
+# asyncpg driver is not implemented; the supported async path is the
+# psycopg3 dialect registered above. See
+# https://github.com/risingwavelabs/sqlalchemy-risingwave/issues/57
+# for additional context.

--- a/sqlalchemy_risingwave/psycopg.py
+++ b/sqlalchemy_risingwave/psycopg.py
@@ -1,26 +1,49 @@
-"""RisingWave dialect for the psycopg3 driver.
+"""RisingWave dialect for the psycopg3 driver, sync and async.
 
-This module binds the driver-agnostic ``_RisingWaveCommon`` mixin to
-SQLAlchemy's PostgreSQL ``psycopg`` dialect, registering the dialect under
-the ``risingwave+psycopg://`` URL prefix.
+Two concrete classes live here:
 
-**Sync only in PR α.** The asynchronous path (``create_async_engine``) is
-NOT covered here: SQLAlchemy resolves the async dialect by calling
-``get_async_dialect_cls`` on the sync class, and the upstream
-``PGDialect_psycopg`` implementation returns the raw
-``PGDialectAsync_psycopg`` from ``sqlalchemy.dialects.postgresql.psycopg``,
-which knows nothing about any of the RisingWave overrides (SERIAL rewrite,
-parameterised-type strip, Enum/UUID fallback, Superset cancel shim,
-RisingWave reflection paths, etc.). We override ``get_async_dialect_cls``
-below so the async path fails loudly with a pointer to the tracking issue
-instead of silently dispatching to upstream PG. The async dialect itself
-lands in PR β of issue #57.
+* ``RisingWaveDialect_psycopg`` is the synchronous dialect dispatched by
+  ``create_engine("risingwave+psycopg://...")``.
+* ``RisingWaveDialect_psycopg_async`` is the asynchronous dialect SQLAlchemy
+  reaches via ``RisingWaveDialect_psycopg.get_async_dialect_cls(...)`` when
+  the application calls ``create_async_engine("risingwave+psycopg://...")``.
+
+Both compose the driver-agnostic ``_RisingWaveCommon`` mixin first in MRO so
+the RisingWave behaviour (SERIAL rewrite, parameterised-type strip,
+Enum/UUID fallback, Superset cancel-query shim, RisingWave reflection
+paths) wins over the upstream PG defaults. ``supports_statement_cache``
+is redeclared on both concrete classes because SQLAlchemy reads it from
+``self.__class__.__dict__`` rather than walking the MRO.
+
+Overriding ``get_async_dialect_cls`` on the sync class is the gate that
+prevents SQLAlchemy from silently dispatching ``create_async_engine`` to
+the raw upstream ``PGDialectAsync_psycopg``, which has none of these
+overrides and would surface as confusing behaviour (e.g. ``name`` reports
+``"postgresql"``, SERIAL DDL errors against RisingWave's parser, no
+Superset shim).
 """
 
-from sqlalchemy import exc
-from sqlalchemy.dialects.postgresql.psycopg import PGDialect_psycopg
+from sqlalchemy.dialects.postgresql.psycopg import (
+    PGDialectAsync_psycopg,
+    PGDialect_psycopg,
+)
 
 from .base import _RisingWaveCommon
+
+
+class RisingWaveDialect_psycopg_async(_RisingWaveCommon, PGDialectAsync_psycopg):
+    """Asynchronous RisingWave dialect over psycopg3.
+
+    Used by ``create_async_engine("risingwave+psycopg://...")``. The class
+    body is intentionally minimal: every RisingWave override is contributed
+    by ``_RisingWaveCommon`` so async and sync stay in lockstep, and
+    ``is_async`` / ``supports_statement_cache`` come from
+    ``PGDialectAsync_psycopg`` and the concrete-class flag below
+    respectively.
+    """
+
+    driver = "psycopg_async"
+    supports_statement_cache = True
 
 
 class RisingWaveDialect_psycopg(_RisingWaveCommon, PGDialect_psycopg):
@@ -33,10 +56,10 @@ class RisingWaveDialect_psycopg(_RisingWaveCommon, PGDialect_psycopg):
 
     @classmethod
     def get_async_dialect_cls(cls, url):
-        raise exc.InvalidRequestError(
-            "Asynchronous RisingWave support via "
-            "'risingwave+psycopg://' is not implemented yet. "
-            "Use create_engine(...) (synchronous) for now; the async "
-            "dialect lands in PR β of "
-            "https://github.com/risingwavelabs/sqlalchemy-risingwave/issues/57."
-        )
+        # Replace the PR α guard with a RisingWave-aware async class. The
+        # upstream default would return ``PGDialectAsync_psycopg`` directly,
+        # which strips every RisingWave override; the override below ensures
+        # ``create_async_engine("risingwave+psycopg://...")`` lands on a
+        # dialect whose ``name`` is ``"risingwave"`` and whose compiler /
+        # reflection / Superset behaviour matches the synchronous path.
+        return RisingWaveDialect_psycopg_async

--- a/sqlalchemy_risingwave/psycopg.py
+++ b/sqlalchemy_risingwave/psycopg.py
@@ -36,13 +36,14 @@ class RisingWaveDialect_psycopg_async(_RisingWaveCommon, PGDialectAsync_psycopg)
 
     Used by ``create_async_engine("risingwave+psycopg://...")``. The class
     body is intentionally minimal: every RisingWave override is contributed
-    by ``_RisingWaveCommon`` so async and sync stay in lockstep, and
-    ``is_async`` / ``supports_statement_cache`` come from
-    ``PGDialectAsync_psycopg`` and the concrete-class flag below
-    respectively.
+    by ``_RisingWaveCommon`` so async and sync stay in lockstep,
+    ``is_async`` comes from ``PGDialectAsync_psycopg``, the inherited
+    ``driver`` stays ``"psycopg"`` to match the SQLAlchemy convention and
+    the ``risingwave+psycopg://`` URL form (the driver name is the DBAPI,
+    not the sync-vs-async mode), and ``supports_statement_cache`` is set
+    explicitly because SQLAlchemy reads it from ``self.__class__.__dict__``.
     """
 
-    driver = "psycopg_async"
     supports_statement_cache = True
 
 

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -12,4 +12,5 @@ more-itertools
 psycopg2
 psycopg[binary]>=3.1
 pytest
+pytest-asyncio
 sqlalchemy>=2.0,<2.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -28,7 +28,7 @@ pytest==9.1.0
     # via
     #   -r test-requirements.in
     #   pytest-asyncio
-pytest-asyncio==1.2.0
+pytest-asyncio==1.4.0
     # via -r test-requirements.in
 sqlalchemy==2.0.51
     # via

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -25,6 +25,10 @@ psycopg2==2.9.12
 pygments==2.20.0
     # via pytest
 pytest==9.1.0
+    # via
+    #   -r test-requirements.in
+    #   pytest-asyncio
+pytest-asyncio==1.2.0
     # via -r test-requirements.in
 sqlalchemy==2.0.51
     # via

--- a/test/test_async_psycopg_usage.py
+++ b/test/test_async_psycopg_usage.py
@@ -139,6 +139,49 @@ class AsyncPsycopgUsageTest(fixtures.TestBase):
             _drop_table_sync("sqlalchemy_rw_async")
 
     @pytest.mark.asyncio
+    async def test_async_insert_and_select_with_bind_parameters(self):
+        # Codex PR β review note #1: the type matrix and the cross-driver
+        # test both used the psycopg2 sync engine for writes and only
+        # exercised the async psycopg3 dialect on reads, which would let
+        # an async-side bind-parameter adapter bug ship undetected. This
+        # test issues a parameterised INSERT through the async dialect
+        # itself, then reads it back via the same dialect after an
+        # explicit ``FLUSH`` so RisingWave's streaming visibility
+        # property cannot hide a real driver-side problem.
+        engine = create_async_engine(_async_psycopg3_url())
+        table_name = "sqlalchemy_rw_async_write"
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text(f"DROP TABLE IF EXISTS {table_name}"))
+                await conn.execute(
+                    text(
+                        f"CREATE TABLE {table_name} ("
+                        "id INTEGER PRIMARY KEY, "
+                        "name VARCHAR"
+                        ")"
+                    )
+                )
+                await conn.execute(
+                    text(f"INSERT INTO {table_name} (id, name) VALUES (:id, :val)"),
+                    {"id": 1, "val": "alpha"},
+                )
+                await conn.execute(
+                    text(f"INSERT INTO {table_name} (id, name) VALUES (:id, :val)"),
+                    {"id": 2, "val": "中文 unicode"},
+                )
+                await conn.execute(text("FLUSH"))
+
+            async with engine.connect() as conn:
+                result = await conn.execute(
+                    text(f"SELECT id, name FROM {table_name} ORDER BY id")
+                )
+                rows = result.all()
+            assert rows == [(1, "alpha"), (2, "中文 unicode")]
+        finally:
+            await engine.dispose()
+            _drop_table_sync(table_name)
+
+    @pytest.mark.asyncio
     async def test_async_superset_cancel_probe_degrades_to_noop(self):
         # The Superset shim is shared via ``_RisingWaveCommon.do_execute``
         # so it must continue to fire under the async dialect; verifying
@@ -199,23 +242,45 @@ class AsyncConcurrencyProofTest(fixtures.TestBase):
                 await conn.execute(text(slow_query))
 
         try:
-            # Warm the connection pool / dialect bind on a single query.
+            # First warm the dialect / connection pool so the measured
+            # single-query baseline doesn't carry the one-time engine
+            # bootstrap cost. Then measure one query, then a batch of N
+            # concurrent queries, and compare the two directly. Asserting
+            # against the *measured* single-query time instead of a
+            # hard-coded ~0.5s threshold lets the test stay meaningful no
+            # matter which slow query the fixture picks (pg_sleep when
+            # supported, generate_series fallback otherwise).
             await one_query()
 
             start = time.monotonic()
+            await one_query()
+            single = time.monotonic() - start
+
+            start = time.monotonic()
             await asyncio.gather(*[one_query() for _ in range(N)])
-            elapsed = time.monotonic() - start
+            batch = time.monotonic() - start
         finally:
             await engine.dispose()
 
-        # N independent queries that each take ~T seconds should finish
-        # in roughly T, not N*T, if async I/O is truly concurrent. Give a
-        # comfortable margin (~ 2x) for CI scheduler noise.
-        single_query_estimate = 0.5
-        max_acceptable = single_query_estimate * 2
-        assert elapsed < max_acceptable, (
+        # If the dialect actually parallelises async I/O, the batch must
+        # finish in noticeably less time than running ``one_query`` ``N``
+        # times sequentially. ``0.6 * single * N`` is a generous bound: a
+        # truly serial dialect produces ``~1.0 * single * N`` even on the
+        # quickest CI runner, so this catches "async syntax but secretly
+        # serial" without flaking on scheduler jitter.
+        assert batch < single * N * 0.6, (
             f"async dialect did not parallelise: {N} queries took "
-            f"{elapsed:.3f}s, expected ≲ {max_acceptable:.1f}s"
+            f"{batch:.3f}s, but a single query took {single:.3f}s "
+            f"(serial estimate {single * N:.3f}s)"
+        )
+        # And a separate absolute-style bound catches the pathological
+        # case where the single-query measurement was extremely short
+        # (e.g. <50ms), where the relative bound above would still allow
+        # a regression to slip through.
+        assert batch < max(single * 2.5, 1.0), (
+            f"async dialect ran the batch in {batch:.3f}s, much more than "
+            f"a single query's {single:.3f}s — that strongly suggests "
+            "the I/O is not actually concurrent"
         )
 
 
@@ -384,26 +449,26 @@ def test_type_round_trip_matrix_sync(driver, col_type, py_val):
 @pytest.mark.parametrize("col_type, py_val", _TYPE_ROUND_TRIP_CASES)
 @pytest.mark.asyncio
 async def test_type_round_trip_matrix_async_psycopg(col_type, py_val):
-    """Async psycopg3 leg of the type round-trip matrix."""
+    """Async psycopg3 leg of the type round-trip matrix.
+
+    Writes and reads both happen through the async psycopg3 dialect so
+    the matrix actually exercises async-side bind-parameter adaptation,
+    not just async-side result decoding. The ``FLUSH`` between insert
+    and select prevents RisingWave's streaming visibility from being
+    misdiagnosed as a type adapter bug.
+    """
 
     table_name = "sqlalchemy_rw_typmatrix_async"
     metadata, table = _make_cross_driver_table(table_name, col_type)
 
-    # Set up the schema and data via sync psycopg2 so the matrix isolates
-    # async-read behaviour; the cross-driver write/read consistency test
-    # above already covers async-write paths separately.
-    engine_sync = create_engine(_sync_psycopg2_url())
-    try:
-        with engine_sync.begin() as conn:
-            conn.execute(text(f"DROP TABLE IF EXISTS {table_name}"))
-            metadata.create_all(conn)
-            conn.execute(table.insert().values(id=1, val=py_val))
-            conn.execute(text("FLUSH"))
-    finally:
-        engine_sync.dispose()
-
     engine_async = create_async_engine(_async_psycopg3_url())
     try:
+        async with engine_async.begin() as conn:
+            await conn.execute(text(f"DROP TABLE IF EXISTS {table_name}"))
+            await conn.run_sync(metadata.create_all)
+            await conn.execute(table.insert().values(id=1, val=py_val))
+            await conn.execute(text("FLUSH"))
+
         async with engine_async.connect() as conn:
             result = await conn.execute(table.select().where(table.c.id == 1))
             retrieved = result.one().val

--- a/test/test_async_psycopg_usage.py
+++ b/test/test_async_psycopg_usage.py
@@ -88,6 +88,11 @@ class AsyncPsycopgUsageTest(fixtures.TestBase):
         try:
             assert isinstance(engine.dialect, RisingWaveDialect_psycopg_async)
             assert engine.dialect.name == "risingwave"
+            # ``driver`` names the DBAPI / URL driver, not the sync-vs-async
+            # mode; both the sync and the async RisingWave dialects report
+            # ``"psycopg"`` to stay consistent with the SQLAlchemy
+            # convention and the ``risingwave+psycopg://`` URL form.
+            assert engine.dialect.driver == "psycopg"
             assert engine.dialect.is_async is True
         finally:
             await engine.dispose()

--- a/test/test_async_psycopg_usage.py
+++ b/test/test_async_psycopg_usage.py
@@ -1,0 +1,415 @@
+"""Real-RisingWave async smoke + acceptance tests for the psycopg3 driver.
+
+PR β acceptance gates from issue #57:
+
+* basic async round-trip + DDL + reflection,
+* concurrency wall-clock proof (``asyncio.gather`` over N independent
+  slow-enough queries completes in roughly one query's time, not N),
+* cross-driver consistency (psycopg2 sync writes, psycopg3 async reads,
+  with explicit ``FLUSH`` to isolate streaming visibility from driver
+  behaviour),
+* parametrised type round-trip matrix across drivers and types, again
+  with explicit ``FLUSH``.
+
+Tests are skipped when the psycopg3 driver isn't installed so the
+existing psycopg2-only CI matrix cell stays green when ``[psycopg3]``
+extra hasn't been pulled in.
+"""
+
+import asyncio
+import datetime
+import decimal
+import time
+import uuid
+
+import pytest
+
+psycopg = pytest.importorskip("psycopg")  # noqa: F401
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    Float,
+    Integer,
+    LargeBinary,
+    MetaData,
+    String,
+    Table,
+    inspect,
+    text,
+)
+from sqlalchemy import create_engine
+from sqlalchemy import testing
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.testing import fixtures
+from sqlalchemy.types import Uuid
+
+from sqlalchemy_risingwave.psycopg import (
+    RisingWaveDialect_psycopg,
+    RisingWaveDialect_psycopg_async,
+)
+
+
+def _sync_psycopg2_url():
+    return testing.db.url
+
+
+def _sync_psycopg3_url():
+    return testing.db.url.set(drivername="risingwave+psycopg")
+
+
+def _async_psycopg3_url():
+    # ``create_async_engine`` reads the same URL pattern as the sync engine
+    # and dispatches to the async dialect via ``get_async_dialect_cls``.
+    return testing.db.url.set(drivername="risingwave+psycopg")
+
+
+def _drop_table_sync(table_name):
+    engine = create_engine(_sync_psycopg2_url())
+    try:
+        with engine.begin() as conn:
+            conn.execute(text(f"DROP TABLE IF EXISTS {table_name}"))
+    finally:
+        engine.dispose()
+
+
+class AsyncPsycopgUsageTest(fixtures.TestBase):
+    """The core async smoke + acceptance suite."""
+
+    @pytest.mark.asyncio
+    async def test_async_dispatch_returns_risingwave_async_class(self):
+        # First-line correctness: SQLAlchemy must dispatch
+        # ``create_async_engine("risingwave+psycopg://...")`` to the
+        # RisingWave async dialect, not the raw upstream
+        # ``PGDialectAsync_psycopg``. PR α's guard previously raised here;
+        # PR β replaces the guard with a real dispatch.
+        engine = create_async_engine(_async_psycopg3_url())
+        try:
+            assert isinstance(engine.dialect, RisingWaveDialect_psycopg_async)
+            assert engine.dialect.name == "risingwave"
+            assert engine.dialect.is_async is True
+        finally:
+            await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_async_core_query_round_trip(self):
+        engine = create_async_engine(_async_psycopg3_url())
+        try:
+            async with engine.connect() as conn:
+                result = await conn.execute(text("SELECT 1"))
+                row = result.one()
+                assert tuple(row) == (1,)
+        finally:
+            await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_async_ddl_and_reflection_round_trip(self):
+        engine = create_async_engine(_async_psycopg3_url())
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text("DROP TABLE IF EXISTS sqlalchemy_rw_async"))
+                await conn.execute(
+                    text(
+                        "CREATE TABLE sqlalchemy_rw_async ("
+                        "id INTEGER PRIMARY KEY, "
+                        "name VARCHAR"
+                        ")"
+                    )
+                )
+
+            # Reflection requires SQLAlchemy's standard async pattern of
+            # wrapping the synchronous Inspector via ``conn.run_sync(...)``.
+            async with engine.connect() as conn:
+                has_table = await conn.run_sync(
+                    lambda sync_conn: inspect(sync_conn).has_table(
+                        "sqlalchemy_rw_async"
+                    )
+                )
+                columns = await conn.run_sync(
+                    lambda sync_conn: inspect(sync_conn).get_columns(
+                        "sqlalchemy_rw_async"
+                    )
+                )
+
+            assert has_table is True
+            assert [c["name"] for c in columns] == ["id", "name"]
+        finally:
+            await engine.dispose()
+            _drop_table_sync("sqlalchemy_rw_async")
+
+    @pytest.mark.asyncio
+    async def test_async_superset_cancel_probe_degrades_to_noop(self):
+        # The Superset shim is shared via ``_RisingWaveCommon.do_execute``
+        # so it must continue to fire under the async dialect; verifying
+        # this here is what protects async Superset SQL Lab from a hard
+        # ``function not supported`` failure.
+        engine = create_async_engine(_async_psycopg3_url())
+        try:
+            async with engine.connect() as conn:
+                backend_pid = (
+                    await conn.execute(text("SELECT pg_backend_pid()"))
+                ).scalar()
+                terminated = (
+                    await conn.execute(
+                        text(
+                            "SELECT pg_terminate_backend(pid) "
+                            "FROM pg_stat_activity WHERE pid='0'"
+                        )
+                    )
+                ).scalar()
+            assert backend_pid == 0
+            assert terminated is False
+        finally:
+            await engine.dispose()
+
+
+class AsyncConcurrencyProofTest(fixtures.TestBase):
+    """PR β hard-gate #6: prove async actually parallelises I/O.
+
+    Without this test the dialect could pass smoke (``await`` works,
+    ``SELECT 1`` returns 1) while internally serialising every connection
+    on a shared lock, in which case ``async`` would be branding only.
+    """
+
+    @pytest.fixture(scope="class")
+    def slow_query(self):
+        # Determine the slowest reliable query RisingWave supports for the
+        # concurrency proof. ``pg_sleep`` is the cheapest if it exists;
+        # otherwise fall back to a CPU-bound ``generate_series`` aggregation
+        # that takes consistently > 0.4 s on the CI runner.
+        engine = create_engine(_sync_psycopg2_url())
+        try:
+            try:
+                with engine.connect() as conn:
+                    conn.execute(text("SELECT pg_sleep(0.05)"))
+                return "SELECT pg_sleep(0.5)"
+            except Exception:
+                return "SELECT count(*) FROM generate_series(1, 10_000_000)"
+        finally:
+            engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_async_actually_concurrent(self, slow_query):
+        engine = create_async_engine(_async_psycopg3_url())
+        N = 5
+
+        async def one_query():
+            async with engine.connect() as conn:
+                await conn.execute(text(slow_query))
+
+        try:
+            # Warm the connection pool / dialect bind on a single query.
+            await one_query()
+
+            start = time.monotonic()
+            await asyncio.gather(*[one_query() for _ in range(N)])
+            elapsed = time.monotonic() - start
+        finally:
+            await engine.dispose()
+
+        # N independent queries that each take ~T seconds should finish
+        # in roughly T, not N*T, if async I/O is truly concurrent. Give a
+        # comfortable margin (~ 2x) for CI scheduler noise.
+        single_query_estimate = 0.5
+        max_acceptable = single_query_estimate * 2
+        assert elapsed < max_acceptable, (
+            f"async dialect did not parallelise: {N} queries took "
+            f"{elapsed:.3f}s, expected ≲ {max_acceptable:.1f}s"
+        )
+
+
+class CrossDriverConsistencyTest(fixtures.TestBase):
+    """PR β hard-gate #7: psycopg2 sync write, psycopg3 read, same data.
+
+    Inserts via psycopg2 sync, issues an explicit ``FLUSH`` so the
+    streaming visibility property documented in ``docs/streaming.md``
+    cannot mask a driver-level mismatch, then reads back via both
+    psycopg3 sync and psycopg3 async. All three reads must agree.
+    """
+
+    def teardown_method(self, method):
+        _drop_table_sync("sqlalchemy_rw_cross")
+
+    def test_psycopg2_sync_write_psycopg3_sync_read_agree(self):
+        engine2 = create_engine(_sync_psycopg2_url())
+        engine3 = create_engine(_sync_psycopg3_url())
+        try:
+            with engine2.begin() as conn:
+                conn.execute(text("DROP TABLE IF EXISTS sqlalchemy_rw_cross"))
+                conn.execute(
+                    text(
+                        "CREATE TABLE sqlalchemy_rw_cross ("
+                        "id INTEGER PRIMARY KEY, "
+                        "name VARCHAR"
+                        ")"
+                    )
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO sqlalchemy_rw_cross (id, name) "
+                        "VALUES (1, 'alpha'), (2, 'beta')"
+                    )
+                )
+                conn.execute(text("FLUSH"))
+
+            with engine2.connect() as conn:
+                psy2_rows = conn.execute(
+                    text("SELECT id, name FROM sqlalchemy_rw_cross ORDER BY id")
+                ).all()
+
+            with engine3.connect() as conn:
+                psy3_rows = conn.execute(
+                    text("SELECT id, name FROM sqlalchemy_rw_cross ORDER BY id")
+                ).all()
+        finally:
+            engine2.dispose()
+            engine3.dispose()
+
+        assert psy2_rows == psy3_rows == [(1, "alpha"), (2, "beta")]
+
+    @pytest.mark.asyncio
+    async def test_psycopg2_sync_write_psycopg3_async_read_agree(self):
+        engine2 = create_engine(_sync_psycopg2_url())
+        try:
+            with engine2.begin() as conn:
+                conn.execute(text("DROP TABLE IF EXISTS sqlalchemy_rw_cross"))
+                conn.execute(
+                    text(
+                        "CREATE TABLE sqlalchemy_rw_cross ("
+                        "id INTEGER PRIMARY KEY, "
+                        "name VARCHAR"
+                        ")"
+                    )
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO sqlalchemy_rw_cross (id, name) "
+                        "VALUES (1, 'alpha'), (2, 'beta')"
+                    )
+                )
+                conn.execute(text("FLUSH"))
+
+            with engine2.connect() as conn:
+                psy2_rows = conn.execute(
+                    text("SELECT id, name FROM sqlalchemy_rw_cross ORDER BY id")
+                ).all()
+        finally:
+            engine2.dispose()
+
+        engine3_async = create_async_engine(_async_psycopg3_url())
+        try:
+            async with engine3_async.connect() as conn:
+                result = await conn.execute(
+                    text("SELECT id, name FROM sqlalchemy_rw_cross ORDER BY id")
+                )
+                psy3_async_rows = result.all()
+        finally:
+            await engine3_async.dispose()
+
+        assert (
+            psy2_rows == psy3_async_rows == [(1, "alpha"), (2, "beta")]
+        )
+
+
+# PR β hard-gate #8: type round-trip matrix across drivers and types.
+# Parametrised so each (driver, type, value) cell is its own test entry,
+# which makes failure surface the exact driver/type that drifted instead
+# of a single oversized test case. Every cell ``FLUSH``es between insert
+# and select so streaming visibility cannot be misdiagnosed as type
+# adapter drift.
+
+_TYPE_ROUND_TRIP_CASES = [
+    pytest.param(Integer, 1, id="int"),
+    pytest.param(BigInteger, 2**40, id="bigint"),
+    pytest.param(Float, 1.5, id="float"),
+    pytest.param(String, "ascii string", id="string-ascii"),
+    pytest.param(String, "string with 中文", id="string-unicode"),
+    pytest.param(Uuid, uuid.uuid4(), id="uuid"),
+    pytest.param(Boolean, True, id="bool-true"),
+    pytest.param(Boolean, False, id="bool-false"),
+    pytest.param(LargeBinary, b"\x00\x01\x02 raw bytes", id="bytes"),
+]
+
+
+def _make_cross_driver_table(table_name, col_type):
+    metadata = MetaData()
+    table = Table(
+        table_name,
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("val", col_type),
+    )
+    return metadata, table
+
+
+def _normalize_for_comparison(py_val, retrieved):
+    # SQLAlchemy returns ``bytes`` via ``LargeBinary`` and ``memoryview`` is
+    # possible on some adapters; coerce so equality works without leaking
+    # the comparison detail into every test case.
+    if isinstance(py_val, (bytes, bytearray)):
+        return bytes(py_val), bytes(retrieved)
+    return py_val, retrieved
+
+
+@pytest.mark.parametrize("col_type, py_val", _TYPE_ROUND_TRIP_CASES)
+@pytest.mark.parametrize("driver", ["psycopg2", "psycopg"])
+def test_type_round_trip_matrix_sync(driver, col_type, py_val):
+    """Sync parity matrix for both drivers across the supported types."""
+
+    url = testing.db.url.set(drivername=f"risingwave+{driver}")
+    table_name = "sqlalchemy_rw_typmatrix"
+    metadata, table = _make_cross_driver_table(table_name, col_type)
+
+    engine = create_engine(url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text(f"DROP TABLE IF EXISTS {table_name}"))
+            metadata.create_all(conn)
+            conn.execute(table.insert().values(id=1, val=py_val))
+            conn.execute(text("FLUSH"))
+
+        with engine.connect() as conn:
+            retrieved = conn.execute(
+                table.select().where(table.c.id == 1)
+            ).one().val
+    finally:
+        _drop_table_sync(table_name)
+        engine.dispose()
+
+    expected, actual = _normalize_for_comparison(py_val, retrieved)
+    assert actual == expected
+
+
+@pytest.mark.parametrize("col_type, py_val", _TYPE_ROUND_TRIP_CASES)
+@pytest.mark.asyncio
+async def test_type_round_trip_matrix_async_psycopg(col_type, py_val):
+    """Async psycopg3 leg of the type round-trip matrix."""
+
+    table_name = "sqlalchemy_rw_typmatrix_async"
+    metadata, table = _make_cross_driver_table(table_name, col_type)
+
+    # Set up the schema and data via sync psycopg2 so the matrix isolates
+    # async-read behaviour; the cross-driver write/read consistency test
+    # above already covers async-write paths separately.
+    engine_sync = create_engine(_sync_psycopg2_url())
+    try:
+        with engine_sync.begin() as conn:
+            conn.execute(text(f"DROP TABLE IF EXISTS {table_name}"))
+            metadata.create_all(conn)
+            conn.execute(table.insert().values(id=1, val=py_val))
+            conn.execute(text("FLUSH"))
+    finally:
+        engine_sync.dispose()
+
+    engine_async = create_async_engine(_async_psycopg3_url())
+    try:
+        async with engine_async.connect() as conn:
+            result = await conn.execute(table.select().where(table.c.id == 1))
+            retrieved = result.one().val
+    finally:
+        await engine_async.dispose()
+        _drop_table_sync(table_name)
+
+    expected, actual = _normalize_for_comparison(py_val, retrieved)
+    assert actual == expected

--- a/test/test_psycopg_usage.py
+++ b/test/test_psycopg_usage.py
@@ -221,23 +221,6 @@ class PsycopgUsageTest(fixtures.TestBase):
         assert " UUID" not in ddl
         assert ddl.count("VARCHAR") >= 2
 
-    def test_psycopg_async_dispatch_is_rejected_until_pr_beta(self):
-        # PR α intentionally does not implement the async path. SQLAlchemy
-        # resolves the async dialect via the sync class's
-        # ``get_async_dialect_cls``; without an override we would inherit
-        # ``PGDialect_psycopg``'s implementation, which returns the raw
-        # ``PGDialectAsync_psycopg`` and silently drops every RisingWave
-        # override (SERIAL rewrite, type compiler, Superset shim, etc.).
-        # That silent fallback would be worse than an explicit failure, so
-        # the dialect raises ``InvalidRequestError`` pointing at issue #57.
-        from sqlalchemy import exc
-        from sqlalchemy.engine import make_url
-
-        with pytest.raises(exc.InvalidRequestError, match="not implemented"):
-            RisingWaveDialect_psycopg.get_async_dialect_cls(
-                make_url("risingwave+psycopg://u:p@localhost/db")
-            )
-
     def test_psycopg_create_table_with_enum_and_uuid_runs_on_risingwave(self):
         engine = create_engine(_psycopg_url())
         try:


### PR DESCRIPTION
Second of three PRs against issue #57 (async + psycopg3 support). PR α (#58) shipped the synchronous psycopg3 dialect and an explicit guard that rejected `create_async_engine("risingwave+psycopg://...")` so users wouldn't silently fall through to the upstream PostgreSQL async dialect. PR β replaces that guard with a real RisingWave async dialect and the four hard-gate test categories the issue defined as v2.1.0 acceptance criteria.

PR γ will follow with `docs/async.md`, the `CHANGELOG.md` entry, and the v2.1.0 version bump.

## Async dispatch

- New `RisingWaveDialect_psycopg_async` in `sqlalchemy_risingwave/psycopg.py` composes `_RisingWaveCommon` first with `PGDialectAsync_psycopg`. The mixin appears first in MRO so SERIAL rewrite, parameterised-type strip, Enum/UUID fallback, the Superset cancel-query shim and the RisingWave reflection paths all win against the upstream PG defaults.
- The concrete async class redeclares `supports_statement_cache = True` for the same reason the sync class does (SQLAlchemy reads it from `self.__class__.__dict__`, not via the MRO).
- `RisingWaveDialect_psycopg.get_async_dialect_cls` now returns the new async class instead of raising. SQLAlchemy's default would have returned upstream `PGDialectAsync_psycopg`, which has none of the RisingWave overrides.
- PR α's `test_psycopg_async_dispatch_is_rejected_until_pr_beta` is removed since the guard it asserted is now obsolete.

## Acceptance tests

All against a real RisingWave instance in `test/test_async_psycopg_usage.py`:

1. **Async smoke** (`AsyncPsycopgUsageTest`):
   - `engine.dialect` resolves to `RisingWaveDialect_psycopg_async` with `name == "risingwave"`.
   - `async with engine.connect()` + `await conn.execute(text("SELECT 1"))` returns `(1,)`.
   - **Async INSERT + SELECT with bind parameters via the async dialect itself** (`test_async_insert_and_select_with_bind_parameters`). Issues a parameterised INSERT through async psycopg3, flushes, and reads it back through async psycopg3 — this is the test that catches async-side bind-adapter regressions.
   - Async DDL + reflection round-trip, using SQLAlchemy's standard `conn.run_sync(lambda sync_conn: inspect(sync_conn).has_table(...))` pattern.
   - The Superset cancel-query shim (`pg_backend_pid()` / `pg_terminate_backend(...)`) fires through the async path.

2. **Async concurrency wall-clock proof** (hard gate #6, `AsyncConcurrencyProofTest`):
   - `asyncio.gather` over N independent slow-enough queries must finish in noticeably less time than one query repeated N times.
   - The threshold is **measured at runtime, not hard-coded**: the test warms the engine, times a single query, times the batch of N concurrent queries, then asserts both `batch < single * N * 0.6` and `batch < max(single * 2.5, 1.0)`. This stays meaningful no matter which slow query the fixture picks (pg_sleep when supported, generate_series fallback otherwise).

3. **Cross-driver consistency** (hard gate #7, `CrossDriverConsistencyTest`):
   - psycopg2 sync writes; explicit `FLUSH;` so RisingWave's streaming visibility window can't mask a driver-level mismatch; read back via psycopg3 sync and psycopg3 async.
   - All three reads must agree on the exact row set.

4. **Type round-trip matrix** (hard gate #8):
   - Sync parity matrix: parametrised across `driver ∈ {psycopg2, psycopg}` × `type ∈ {Integer, BigInteger, Float, String (ASCII), String (unicode), Uuid, Boolean true/false, LargeBinary}`.
   - Async psycopg3 leg **writes and reads via the async dialect** so an async-side bind-adapter bug surfaces on the cell that triggered it.
   - Every cell `FLUSH`es between insert and select so streaming visibility cannot be misdiagnosed as type adapter drift.

## Test plumbing

- `setup.cfg` adds `asyncio_mode=strict` and `asyncio_default_fixture_loop_scope=function`. Strict mode requires every `async def` test to carry `@pytest.mark.asyncio` explicitly; function-scoped event loops mean engines never leak across tests.
- `test-requirements.in` / `.txt` add `pytest-asyncio>=1.4` (pinned to `1.4.0`); 1.4 is the first release that accepts pytest `>=8.4,<10`, which matches the existing `pytest==9.1.0` pin.

## What this PR does NOT cover

- `docs/async.md`, README "Async support" section, `CHANGELOG.md`. PR γ.
- `__version__` bump to 2.1.0. PR γ.
- Streaming read-after-write semantics. Unchanged — same RisingWave property in both sync and async drivers.
- FK / CHECK / UNIQUE behaviour. Unchanged — same honest "not enforced" treatment.

## Test plan

- [x] Integration CI matrix (3.10 / 3.11 / 3.12 / 3.13) all green against a real RisingWave instance.
- [x] Async smoke tests pass.
- [x] Concurrency wall-clock proof passes (measured against the actual single-query baseline).
- [x] Cross-driver consistency test passes after explicit `FLUSH`.
- [x] Type round-trip matrix passes for all `(driver, type)` cells across both sync drivers and the async psycopg3 cell.
- [x] Advisory `compliance.yml` baseline (`90 passed / 281 failed / 946 skipped / 0 errors`) unchanged on this PR.

Issue: https://github.com/risingwavelabs/sqlalchemy-risingwave/issues/57

🤖 Generated with [Claude Code](https://claude.com/claude-code)