### PR TITLE
docs: v2.1.0 release prep (PR γ of #57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## 2.1.0 - 2026-06-18
+
+Adds the psycopg3 driver path — synchronous and asynchronous — to the
+existing psycopg2 sync dialect. No behaviour on the existing
+`risingwave+psycopg2://` URL changes; 2.1.0 is a backwards-compatible
+addition.
+
+### Added
+
+- psycopg3 driver support via `risingwave+psycopg://` URLs. Sync engines
+  resolve to `RisingWaveDialect_psycopg`; async engines resolve to
+  `RisingWaveDialect_psycopg_async` via the sync class's
+  `get_async_dialect_cls` override, keeping every RisingWave behaviour
+  (compilers, capability flags, reflection, Superset cancel-query shim)
+  consistent across both paths.
+- SQLAlchemy `create_async_engine("risingwave+psycopg://...")` is now
+  supported. The previous `InvalidRequestError` guard from 2.0.x is
+  removed because the underlying async dialect is in place.
+- Optional `psycopg3` extras: `pip install "sqlalchemy-risingwave[psycopg3]"`.
+- A documentation page at `docs/async.md` covering the async usage
+  pattern, FastAPI sketch, the streaming visibility reminder, and the
+  exact set of behaviours every PR validates against a real RisingWave
+  instance in CI.
+- README "Async support" section.
+
+### Changed
+
+- The driver-agnostic RisingWave behaviour has moved from the
+  `RisingWaveDialect` class into a new `_RisingWaveCommon` mixin. The
+  `RisingWaveDialect` name is preserved as an import alias on the
+  psycopg2 path; downstream code that imports it from
+  `sqlalchemy_risingwave.base` continues to work without modification.
+
+### Tests
+
+The new advisory CI gates land alongside the dialect:
+
+- Cross-driver round trip: data written via psycopg2 sync is read back
+  identically through psycopg3 sync and psycopg3 async, with an
+  explicit `FLUSH` so RisingWave's streaming visibility window can't
+  mask a driver-level mismatch.
+- Parametrised type round-trip matrix across driver
+  (psycopg2, psycopg) × type (Integer, BigInteger, Float, String
+  ASCII / unicode, UUID, Boolean true/false, LargeBinary).
+- Async wall-clock proof that `asyncio.gather` actually parallelises
+  I/O — the test measures one query's elapsed time and asserts the
+  batch of N queries completes in noticeably less than that, so a
+  dialect that secretly serialised every connection would fail loudly.
+
+### Known limitations
+
+- The asyncpg driver is still not implemented; the supported async
+  path is psycopg3 via `risingwave+psycopg://`.
+- Read-after-write visibility is unchanged in either driver: an
+  `INSERT` is not guaranteed to be visible to a subsequent `SELECT`
+  until a checkpoint barrier has passed or the user explicitly runs
+  `FLUSH;`. async does not change this. See `docs/streaming.md`.
+
 ## 2.0.0 - 2026-06-17
 
 This release updates `sqlalchemy-risingwave` for SQLAlchemy 2.0.x and documents the dialect's current compatibility boundary against real RisingWave.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,10 @@ addition.
 
 ### Tests
 
-The new advisory CI gates land alongside the dialect:
+The new merge-gating integration tests land alongside the dialect.
+They run against a real RisingWave instance via
+``.github/workflows/test.yml`` and a failure blocks merge. The
+``compliance.yml`` workflow remains advisory and is unchanged.
 
 - Cross-driver round trip: data written via psycopg2 sync is read back
   identically through psycopg3 sync and psycopg3 async, with an

--- a/README.md
+++ b/README.md
@@ -35,6 +35,44 @@ pip install -e . # install this package
 
 See how to use with Superset: [doc](./doc/integrate_with_superset.md)
 
+## Async support
+
+Released in v2.1.0. RisingWave can now be driven from SQLAlchemy 2.0's
+async engine API via the psycopg3 driver. Install the dialect with the
+optional `psycopg3` extra:
+
+```sh
+pip install -U "sqlalchemy-risingwave[psycopg3]"
+```
+
+Sync and async both go through the same `risingwave+psycopg://` URL —
+SQLAlchemy picks the right dialect class from the engine factory:
+
+```python
+from sqlalchemy import create_engine, text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+# Sync
+sync_engine = create_engine("risingwave+psycopg://root@localhost:4566/dev")
+
+# Async
+async_engine = create_async_engine("risingwave+psycopg://root@localhost:4566/dev")
+
+async with async_engine.connect() as conn:
+    result = await conn.execute(text("SELECT 1"))
+    print(result.scalar_one())
+```
+
+The legacy `risingwave+psycopg2://` URL is sync only — psycopg2 itself
+has no async mode. async-only drivers such as `asyncpg` are not
+implemented; the supported async path is psycopg3.
+
+See [`docs/async.md`](docs/async.md) for the full usage guide, the
+FastAPI sketch, the read-after-write reminder (RisingWave streaming
+visibility still applies — async does not change it), and the list of
+behaviour each PR is required to validate against a real RisingWave
+instance in CI.
+
 ## SQLAlchemy compatibility
 
 This dialect targets SQLAlchemy 2.0+. RisingWave's SQL surface is

--- a/README.md
+++ b/README.md
@@ -49,18 +49,32 @@ Sync and async both go through the same `risingwave+psycopg://` URL —
 SQLAlchemy picks the right dialect class from the engine factory:
 
 ```python
+import asyncio
+
 from sqlalchemy import create_engine, text
 from sqlalchemy.ext.asyncio import create_async_engine
 
+
 # Sync
 sync_engine = create_engine("risingwave+psycopg://root@localhost:4566/dev")
+with sync_engine.connect() as conn:
+    print(conn.execute(text("SELECT 1")).scalar_one())
+
 
 # Async
-async_engine = create_async_engine("risingwave+psycopg://root@localhost:4566/dev")
+async def main():
+    async_engine = create_async_engine(
+        "risingwave+psycopg://root@localhost:4566/dev"
+    )
+    try:
+        async with async_engine.connect() as conn:
+            result = await conn.execute(text("SELECT 1"))
+            print(result.scalar_one())
+    finally:
+        await async_engine.dispose()
 
-async with async_engine.connect() as conn:
-    result = await conn.execute(text("SELECT 1"))
-    print(result.scalar_one())
+
+asyncio.run(main())
 ```
 
 The legacy `risingwave+psycopg2://` URL is sync only — psycopg2 itself

--- a/docs/async.md
+++ b/docs/async.md
@@ -1,0 +1,218 @@
+# Async SQLAlchemy with RisingWave
+
+`sqlalchemy-risingwave` ships an async dialect that lets applications drive
+RisingWave from `asyncio` event loops via SQLAlchemy 2.0's async engine
+API. This page describes what the async path solves, what it does **not**
+solve, and how to wire it up against the underlying psycopg3 driver.
+
+## What async actually changes
+
+Python's `async` / `await` syntax is a concurrency model: at every
+`await` point a coroutine can be suspended and the event loop can run a
+different coroutine while the I/O is in flight. The dialect side of that
+deal is that `await connection.execute(...)` returns the thread to the
+event loop while the network round-trip to RisingWave is pending, so a
+single-threaded process can have many SELECTs in flight at once.
+
+This is the property that lets a FastAPI / Starlette / Tornado /
+Quart-style web server serve hundreds or thousands of concurrent
+requests on one OS thread.
+
+Async **does not** change:
+
+* RisingWave server-side latency. A query that takes 50 ms synchronously
+  still takes 50 ms when awaited; you're just not blocking the event
+  loop while it runs.
+* RisingWave streaming visibility. `INSERT` into RisingWave is not
+  immediately visible to a subsequent `SELECT` (see
+  [`docs/streaming.md`](streaming.md)). That property is intrinsic to
+  RisingWave's streaming pipeline, not to whether the client is sync or
+  async. Async clients see exactly the same window as sync clients.
+* Enforcement of `CHECK` / `UNIQUE` / `FOREIGN KEY` constraints. Those
+  are not enforced by RisingWave in either driver mode.
+
+## Driver requirements
+
+The async path is implemented on top of [psycopg3]; install the dialect
+with the `psycopg3` extra:
+
+```
+pip install -U "sqlalchemy-risingwave[psycopg3]"
+```
+
+The legacy `risingwave+psycopg2://` URL is sync-only. The async dialect
+only resolves through the `risingwave+psycopg://` URL family.
+
+[psycopg3]: https://www.psycopg.org/psycopg3/docs/
+
+## Basic usage
+
+```python
+import asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+async def main():
+    engine = create_async_engine(
+        "risingwave+psycopg://root@localhost:4566/dev"
+    )
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(text("SELECT 1"))
+            print(result.scalar_one())
+    finally:
+        await engine.dispose()
+
+
+asyncio.run(main())
+```
+
+`engine.dialect.driver` reports `"psycopg"` for both the sync and the
+async engine; `engine.dialect.is_async` is `True` only on the async
+engine. The driver name follows SQLAlchemy convention — it identifies
+the DBAPI, not the sync-vs-async mode.
+
+## ORM `AsyncSession`
+
+```python
+from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class User(Base):
+    __tablename__ = "users"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+
+
+async_session = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def fetch_alpha():
+    async with async_session() as session:
+        result = await session.execute(
+            select(User).where(User.name == "alpha")
+        )
+        return result.scalars().all()
+```
+
+## Reflection
+
+SQLAlchemy's `inspect(...)` API is synchronous because it walks the
+catalog through one connection. Wrap it via `conn.run_sync` to use it
+from an async connection:
+
+```python
+async with engine.connect() as conn:
+    has_users = await conn.run_sync(
+        lambda sync_conn: inspect(sync_conn).has_table("users")
+    )
+    columns = await conn.run_sync(
+        lambda sync_conn: inspect(sync_conn).get_columns("users")
+    )
+```
+
+This is the standard SQLAlchemy 2.0 pattern and is not RisingWave
+specific. The dialect's reflection methods (`get_pk_constraint`,
+`get_columns`, `get_table_names`, etc.) are reused as-is.
+
+## FastAPI sketch
+
+```python
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+
+def make_app() -> FastAPI:
+    engine = create_async_engine(
+        "risingwave+psycopg://root@localhost:4566/dev"
+    )
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        try:
+            yield {"session_factory": session_factory}
+        finally:
+            await engine.dispose()
+
+    app = FastAPI(lifespan=lifespan)
+
+    @app.get("/healthz")
+    async def healthz():
+        async with session_factory() as session:
+            await session.execute(text("SELECT 1"))
+        return {"status": "ok"}
+
+    return app
+```
+
+## Read-after-write reminder
+
+If your application code follows a write with an immediate read in the
+same async block:
+
+```python
+async with session.begin():
+    session.add(User(id=1, name="alpha"))
+    # This SELECT can return zero rows on RisingWave, regardless of
+    # whether the engine is sync or async.
+    rows = (await session.execute(select(User))).all()
+```
+
+…the second statement can return empty data. This is RisingWave's
+streaming-visibility behaviour, documented in
+[`docs/streaming.md`](streaming.md), not a defect of the async dialect.
+The patterns recommended there — treat RisingWave as a sink, avoid
+write-then-read in the same transaction, supply application-allocated
+ids — apply to async code identically.
+
+`FLUSH;` is still the explicit knob if you really need synchronous
+visibility:
+
+```python
+async with engine.begin() as conn:
+    await conn.execute(text("INSERT INTO users (id, name) VALUES (1, 'alpha')"))
+    await conn.execute(text("FLUSH"))
+
+async with engine.connect() as conn:
+    rows = (await conn.execute(text("SELECT id FROM users"))).all()
+```
+
+Whether the dialect should issue `FLUSH` automatically on every commit
+(a `FLUSH`-on-commit mode) is an open product trade-off discussed in
+the streaming-visibility document; it is not enabled by default.
+
+## What is and is not covered by CI
+
+Every `sqlalchemy-risingwave` pull request that touches the dialect
+runs `test/test_async_psycopg_usage.py` against a real RisingWave
+instance. The async tests cover:
+
+* `create_async_engine("risingwave+psycopg://...")` dispatch and that
+  the resolved class has `name == "risingwave"`, `driver == "psycopg"`,
+  and `is_async is True`.
+* `SELECT` round-trip and a parameterised `INSERT` then `SELECT` (the
+  latter is what proves the async bind-parameter adapter works).
+* The Superset cancel-query shim through the async dialect.
+* Wall-clock proof that `asyncio.gather` actually parallelises I/O —
+  the test asserts the batch of N independent queries finishes in
+  meaningfully less time than running them sequentially.
+* Cross-driver consistency: data inserted via psycopg2 sync is read
+  back identically through psycopg3 sync and psycopg3 async (with an
+  explicit `FLUSH`).
+* A parametrised type round-trip matrix across all supported drivers
+  and SQLAlchemy types (Integer, BigInteger, Float, String ASCII /
+  unicode, UUID, Boolean, LargeBinary).
+
+If your async code path exercises behaviour outside this list, please
+open an issue — there is no E2E coverage for arbitrary frameworks yet,
+just the dialect-level contracts above.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -98,6 +98,12 @@ explicit property of the database.
   RisingWave's streaming model is doing exactly what it should — eventually
   materialising writes. The two designs disagree, and this document is where
   that disagreement is recorded.
+* **Not fixed by switching to the async dialect.** The async path added in
+  v2.1.0 lets a single Python process keep many queries in flight on one
+  thread, which is purely a client-side concurrency story. RisingWave's
+  server-side streaming barriers are unchanged, so an async
+  `INSERT` → `SELECT` block has the same visibility window as a sync
+  one. See [`docs/async.md`](async.md).
 
 ## Related code paths
 

--- a/publish.md
+++ b/publish.md
@@ -37,6 +37,7 @@ workflow later.
 8. After PyPI upload succeeds, create and push the matching git tag:
 
    ```sh
-   git tag v2.0.0
-   git push origin v2.0.0
+   VERSION=2.1.0
+   git tag "v$VERSION"
+   git push origin "v$VERSION"
    ```

--- a/sqlalchemy_risingwave/__init__.py
+++ b/sqlalchemy_risingwave/__init__.py
@@ -1,6 +1,6 @@
 from sqlalchemy.dialects import registry as _registry
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 _registry.register(
     "risingwave.psycopg2",


### PR DESCRIPTION
Third and final PR of the async / psycopg3 support track (issue #57). PR α (#58) landed the synchronous psycopg3 dialect and the mixin refactor. PR β (#59) landed the async dialect plus the four hard-gate test categories (async smoke / measured concurrency / cross-driver consistency / type round-trip matrix). This PR closes the track with the user-facing release wrap-up.

## Changes

* **`docs/async.md`** — async usage guide. Covers `create_async_engine` example, ORM `AsyncSession` sketch, the `conn.run_sync` reflection pattern, FastAPI sketch, the read-after-write reminder, and the list of behaviours every PR validates against a real RisingWave instance in CI. Also explicitly calls out what async does *not* solve — RisingWave server-side latency, streaming visibility, constraint enforcement — so the README claim and the user expectation match.
* **`README.md`** — new "Async support" section pointing at `docs/async.md`, with the install command, both URL forms, and the constraint that `risingwave+psycopg2://` stays sync only. The async snippet wraps the await in `async def main()` + `asyncio.run(main())` so it is copy-paste runnable.
* **`docs/streaming.md`** — adds a "Not fixed by switching to the async dialect" bullet under "What this is NOT" so the streaming visibility doc still reads cleanly after the async path ships.
* **`CHANGELOG.md`** — 2.1.0 entry:
  - Added psycopg3 sync + async support via `risingwave+psycopg://`.
  - `[psycopg3]` install extra.
  - Removal of the 2.0.x async `InvalidRequestError` guard.
  - Mixin refactor in `base.py` (back-compat `RisingWaveDialect` import preserved).
  - The new merge-gating integration tests delivered by PR β (cross-driver round trip, type matrix, async concurrency wall-clock proof). Only `compliance.yml` remains advisory.
  - Known limitations: no asyncpg path, read-after-write visibility unchanged in either driver.
* **`publish.md`** — manual-release tag step parameterised via `VERSION=2.1.0` so the example no longer hardcodes the previous release.
* **`sqlalchemy_risingwave/__init__.py`** — `__version__` bumped from `2.0.0` to `2.1.0`.

## What this PR does NOT change

- No runtime behaviour. The dialect classes, CI, test files, and entry points were all delivered in PR α and PR β; this PR is the documentation and version bump only.
- The release upload step. Following the manual flow established for 2.0.0, after this PR merges the project owner runs `python3 -m build` + `twine upload dist/*` on the latest `main` and pushes the matching `v2.1.0` tag.

## Test plan

- [x] Integration CI matrix (3.10 / 3.11 / 3.12 / 3.13) all green — confirms the docs PR did not accidentally break a code path.
- [x] Advisory `compliance.yml` baseline (`90 passed / 281 failed / 946 skipped / 0 errors`) unchanged on this PR.

## Post-merge follow-ups

These are intentionally not part of the PR-merge checklist because they happen after this PR lands.

- Owner builds and publishes `sqlalchemy-risingwave==2.1.0` to PyPI per `publish.md` manual flow; clean-venv `pip install -U sqlalchemy-risingwave` resolves to `2.1.0`.
- Comment on issue #57 with the upgrade path for the original requester and close it.

Issue: https://github.com/risingwavelabs/sqlalchemy-risingwave/issues/57

🤖 Generated with [Claude Code](https://claude.com/claude-code)