### PR TITLE
docs: add runnable async usage example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,16 @@ addition.
   (compilers, capability flags, reflection, Superset cancel-query shim)
   consistent across both paths.
 - SQLAlchemy `create_async_engine("risingwave+psycopg://...")` is now
-  supported. The previous `InvalidRequestError` guard from 2.0.x is
-  removed because the underlying async dialect is in place.
+  supported. The sync `RisingWaveDialect_psycopg.get_async_dialect_cls(...)`
+  dispatches to `RisingWaveDialect_psycopg_async` so both sync and async
+  paths share the `_RisingWaveCommon` overrides.
 - Optional `psycopg3` extras: `pip install "sqlalchemy-risingwave[psycopg3]"`.
 - A documentation page at `docs/async.md` covering the async usage
   pattern, FastAPI sketch, the streaming visibility reminder, and the
   exact set of behaviours every PR validates against a real RisingWave
   instance in CI.
+- A runnable `examples/async_usage.py` script covering minimal SELECT,
+  write → explicit FLUSH → read, and `asyncio.gather` concurrency.
 - README "Async support" section.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ optional `psycopg3` extra:
 pip install -U "sqlalchemy-risingwave[psycopg3]"
 ```
 
+The benefit is Python-side concurrency: while one query is waiting on
+network I/O, the event loop can run other coroutines. This is useful for
+FastAPI / Starlette-style services that need many concurrent RisingWave
+queries from one process. It does **not** make a single RisingWave query
+execute faster, and it does **not** change RisingWave's streaming
+read-after-write visibility (see [`docs/streaming.md`](docs/streaming.md)).
+
 Sync and async both go through the same `risingwave+psycopg://` URL —
 SQLAlchemy picks the right dialect class from the engine factory:
 
@@ -85,7 +92,8 @@ See [`docs/async.md`](docs/async.md) for the full usage guide, the
 FastAPI sketch, the read-after-write reminder (RisingWave streaming
 visibility still applies — async does not change it), and the list of
 behaviour each PR is required to validate against a real RisingWave
-instance in CI.
+instance in CI. A runnable script is available at
+[`examples/async_usage.py`](examples/async_usage.py).
 
 ## SQLAlchemy compatibility
 

--- a/docs/async.md
+++ b/docs/async.md
@@ -45,6 +45,19 @@ only resolves through the `risingwave+psycopg://` URL family.
 
 [psycopg3]: https://www.psycopg.org/psycopg3/docs/
 
+## Runnable example
+
+The repository includes a script that exercises the main async patterns:
+
+```sh
+python examples/async_usage.py
+```
+
+It runs a minimal `SELECT`, a parameterised `INSERT` followed by explicit
+`FLUSH`, and several independent queries through `asyncio.gather` to show
+client-side concurrency. Override the connection URL with
+`RISINGWAVE_ASYNC_URL` when testing against a remote cluster.
+
 ## Basic usage
 
 ```python

--- a/examples/async_usage.py
+++ b/examples/async_usage.py
@@ -1,0 +1,111 @@
+"""Runnable SQLAlchemy asyncio examples for RisingWave.
+
+Prerequisites:
+
+    pip install -U "sqlalchemy-risingwave[psycopg3]"
+
+Run against local RisingWave:
+
+    python examples/async_usage.py
+
+Or point at another cluster:
+
+    RISINGWAVE_ASYNC_URL="risingwave+psycopg://user:pass@host:4566/dev" \
+        python examples/async_usage.py
+
+The examples intentionally include an explicit FLUSH after INSERT. RisingWave
+is a streaming database, so an INSERT is not guaranteed to be visible to a
+subsequent SELECT until a barrier has passed or the application runs FLUSH.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+
+DEFAULT_URL = "risingwave+psycopg://root@localhost:4566/dev"
+
+
+async def minimal_select(engine) -> None:
+    async with engine.connect() as conn:
+        value = (await conn.execute(text("SELECT 1"))).scalar_one()
+    print(f"minimal SELECT -> {value}")
+
+
+async def insert_flush_select(engine) -> None:
+    async with engine.begin() as conn:
+        await conn.execute(text("DROP TABLE IF EXISTS sqlalchemy_async_demo"))
+        await conn.execute(
+            text(
+                "CREATE TABLE sqlalchemy_async_demo ("
+                "id INTEGER PRIMARY KEY, "
+                "name VARCHAR"
+                ")"
+            )
+        )
+        await conn.execute(
+            text(
+                "INSERT INTO sqlalchemy_async_demo (id, name) "
+                "VALUES (:id, :name)"
+            ),
+            {"id": 1, "name": "alpha"},
+        )
+        await conn.execute(text("FLUSH"))
+
+    async with engine.connect() as conn:
+        rows = (
+            await conn.execute(
+                text("SELECT id, name FROM sqlalchemy_async_demo ORDER BY id")
+            )
+        ).all()
+    print(f"INSERT + FLUSH + SELECT -> {rows}")
+
+
+async def concurrency_demo(engine) -> None:
+    """Show async client-side concurrency with several independent queries."""
+
+    # pg_sleep gives the clearest wall-clock demo when the connected
+    # RisingWave version supports it: five one-second sleeps should finish in
+    # roughly one second, not five. Older versions may not expose pg_sleep, so
+    # fall back to a CPU-bound query that still exercises asyncio.gather, but
+    # may not show the same clean timing if the server is CPU-saturated.
+    async with engine.connect() as conn:
+        try:
+            await conn.execute(text("SELECT pg_sleep(0.01)"))
+            slow_query = "SELECT pg_sleep(1)"
+            timing_note = "pg_sleep demo"
+        except Exception:
+            slow_query = "SELECT count(*) FROM generate_series(1, 10000000)"
+            timing_note = "generate_series fallback"
+
+    query_count = 5
+
+    async def one_query(i: int) -> None:
+        async with engine.connect() as conn:
+            await conn.execute(text(slow_query))
+        print(f"concurrent query {i} finished")
+
+    start = time.monotonic()
+    await asyncio.gather(*(one_query(i) for i in range(query_count)))
+    elapsed = time.monotonic() - start
+    print(f"{query_count} independent queries ({timing_note}) finished in {elapsed:.2f}s")
+
+
+async def main() -> None:
+    url = os.environ.get("RISINGWAVE_ASYNC_URL", DEFAULT_URL)
+    engine = create_async_engine(url)
+    try:
+        await minimal_select(engine)
+        await insert_flush_select(engine)
+        await concurrency_demo(engine)
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Adds a runnable async example script and makes the README async section more explicit about the real benefit: Python-side concurrency.\n\nChanges:\n- add examples/async_usage.py with minimal SELECT, INSERT + FLUSH + SELECT, and asyncio.gather concurrency demo\n- link the script from README and docs/async.md\n- clarify in README that async does not reduce single-query latency or change RisingWave streaming visibility\n\nValidation:\n- python3 -m py_compile examples/async_usage.py\n- ran examples/async_usage.py against real local RisingWave: SELECT=1, INSERT+FLUSH row visible, 5 pg_sleep queries finished in 1.01s\n- python3 -m build\n- python3 -m twine check dist/*