### PR TITLE
fix: clarify reflected column type parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ at the data layer — not a silent change to a user-declared invariant:
   unparameterised forms
   ([PR #50](https://github.com/risingwavelabs/sqlalchemy-risingwave/pull/50)).
   RisingWave does not enforce length / precision caps.
+  Reflected columns likewise do not report a `VARCHAR` length. `DECIMAL` /
+  `NUMERIC` precision and scale are populated only when RisingWave exposes
+  them through `information_schema`; current RisingWave versions report them
+  as unknown.
 * `Uuid()` / `UUID` → `VARCHAR` with SQLAlchemy non-native UUID round-trip
   ([PR #51](https://github.com/risingwavelabs/sqlalchemy-risingwave/pull/51)).
   Format validation moves to the application layer.

--- a/sqlalchemy_risingwave/base.py
+++ b/sqlalchemy_risingwave/base.py
@@ -74,6 +74,7 @@ class RisingWaveDDLCompiler(PGDDLCompiler):
             )
         )
 
+
 class RisingWaveTypeCompiler(PGTypeCompiler):
     """Type compiler that drops PostgreSQL-style length / precision arguments.
 
@@ -155,6 +156,69 @@ _type_map = {
 
 
 # Unsupported: Int256, Serial, Struct, List
+
+def _get_column_type_from_information_schema(
+    type_str,
+    column_name,
+    character_maximum_length=None,
+    numeric_precision=None,
+    numeric_scale=None,
+):
+    # RisingWave VARCHAR is unbounded, and current RisingWave rejects
+    # PostgreSQL-style VARCHAR(n) DDL. Do not synthesize a length that the
+    # database does not enforce.
+    del character_maximum_length
+
+    m = re.match(r"^struct<.*>$", type_str)
+    if m:
+        warn("Struct is not supported")
+        return sqltypes.NULLTYPE
+
+    m = re.match(
+        r"^([a-z ]+)(?:\(([^)]*)\))?((\[\])*)$",
+        type_str,
+    )
+    kwargs = {}
+    if m:
+        groups = m.groups()
+        type_name = groups[0]
+        type_args = groups[1]
+
+        if type_name in _type_map:
+            data_type = _type_map[type_name]
+        else:
+            data_type = None
+
+        if type_name == "timestamp with time zone":
+            kwargs["timezone"] = True
+        if type_name in ("numeric", "decimal"):
+            if numeric_precision is not None:
+                kwargs["precision"] = int(numeric_precision)
+            if numeric_scale is not None:
+                kwargs["scale"] = int(numeric_scale)
+            if type_args and numeric_precision is None and numeric_scale is None:
+                numeric_args = [
+                    int(arg.strip()) for arg in type_args.split(",") if arg.strip()
+                ]
+                if len(numeric_args) >= 1:
+                    kwargs["precision"] = numeric_args[0]
+                if len(numeric_args) >= 2:
+                    kwargs["scale"] = numeric_args[1]
+    else:
+        data_type = None
+        groups = None
+
+    if data_type:
+        type_class = data_type(**kwargs)
+        if groups[2]:
+            array_suffixes = re.findall(r"\[\]", groups[2])
+            for _ in array_suffixes:
+                type_class = sqltypes.ARRAY(type_class)
+        return type_class
+
+    warn(f"Did not recognize type '{type_str}' of column '{column_name}'")
+    return sqltypes.NULLTYPE
+
 
 logger = logging.getLogger(__name__)
 _warned_pg_cancel_probe = False
@@ -325,7 +389,8 @@ class _RisingWaveCommon:
     @reflection.cache
     def get_columns(self, conn, table_name, schema=None, **kw):
         sql = (
-            "SELECT column_name, data_type, is_nullable, column_default"
+            "SELECT column_name, data_type, is_nullable, column_default,"
+            " character_maximum_length, numeric_precision, numeric_scale"
             " FROM information_schema.columns WHERE "
             "table_schema = :table_schema AND table_name = :table_name"
         )
@@ -340,54 +405,13 @@ class _RisingWaveCommon:
         res = []
         for row in rows:
             name, type_str = row.column_name, row.data_type
-            # When there are type parameters, attach them to the
-            # returned type object.
-            m = re.match(r"^struct<.*>$", type_str)
-            if m:
-                warn("Struct is not supported")
-                type_class = sqltypes.NULLTYPE
-            else:
-                m = re.match(
-                    r"^([a-z ]+)(?:\(([^)]*)\))?((\[\])*)$",
-                    type_str,
-                )
-                kwargs = {}
-                if m:
-                    groups = m.groups()
-                    type_name = groups[0]
-                    type_args = groups[1]
-
-                    if type_name in _type_map:
-                        data_type = _type_map[type_name]
-                    else:
-                        data_type = None
-
-                    if type_name == "timestamp with time zone":
-                        kwargs["timezone"] = True
-                    if type_name in ("varchar", "character varying") and type_args:
-                        kwargs["length"] = int(type_args)
-                    if type_name in ("numeric", "decimal") and type_args:
-                        numeric_args = [
-                            int(arg.strip())
-                            for arg in type_args.split(",")
-                            if arg.strip()
-                        ]
-                        if len(numeric_args) >= 1:
-                            kwargs["precision"] = numeric_args[0]
-                        if len(numeric_args) >= 2:
-                            kwargs["scale"] = numeric_args[1]
-                else:
-                    data_type = None
-
-                if data_type:
-                    type_class = data_type(**kwargs)
-                    if groups[2]:
-                        array_suffixs = re.findall(r"\[\]", groups[2])
-                        for i in range(0, len(array_suffixs)):
-                            type_class = sqltypes.ARRAY(type_class)
-                else:
-                    warn(f"Did not recognize type '{type_str}' of column '{name}'")
-                    type_class = sqltypes.NULLTYPE
+            type_class = _get_column_type_from_information_schema(
+                type_str,
+                name,
+                character_maximum_length=row.character_maximum_length,
+                numeric_precision=row.numeric_precision,
+                numeric_scale=row.numeric_scale,
+            )
 
             column_info = dict(
                 name=name,

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -3,6 +3,8 @@ from sqlalchemy import MetaData, Table, testing, inspect
 from sqlalchemy.testing import fixtures
 import sqlalchemy.types as sqltypes
 
+from sqlalchemy_risingwave.base import _get_column_type_from_information_schema
+
 
 class SchemaTest(fixtures.TestBase):
 
@@ -124,8 +126,33 @@ class SchemaTest(fixtures.TestBase):
             assert isinstance(columns["txt"], sqltypes.VARCHAR)
             assert isinstance(columns["short_name"], sqltypes.VARCHAR)
             assert isinstance(columns["amount"], sqltypes.DECIMAL)
+            assert columns["short_name"].length is None
+            assert columns["amount"].precision is None
+            assert columns["amount"].scale is None
 
             conn.execute(text("DROP TABLE reflected_types"))
+
+    def test_get_columns_preserves_catalog_numeric_metadata(self):
+        column_type = _get_column_type_from_information_schema(
+            "numeric",
+            "amount",
+            numeric_precision=10,
+            numeric_scale=2,
+        )
+
+        assert isinstance(column_type, sqltypes.DECIMAL)
+        assert column_type.precision == 10
+        assert column_type.scale == 2
+
+    def test_get_columns_does_not_fabricate_varchar_length(self):
+        column_type = _get_column_type_from_information_schema(
+            "character varying",
+            "name",
+            character_maximum_length=12,
+        )
+
+        assert isinstance(column_type, sqltypes.VARCHAR)
+        assert column_type.length is None
 
     def test_get_view_names(self):
         with testing.db.begin() as conn:


### PR DESCRIPTION
## Summary

Closes #9.

This tightens `Inspector.get_columns()` reflection around type parameters:

- Select `character_maximum_length`, `numeric_precision`, and `numeric_scale` from `information_schema.columns`.
- Preserve `DECIMAL` / `NUMERIC` precision and scale when RisingWave exposes those catalog fields.
- Do **not** synthesize `VARCHAR` length from catalog metadata. Current RisingWave treats `VARCHAR` as unbounded and rejects PostgreSQL-style `VARCHAR(n)` DDL, so returning a length would imply an invariant RisingWave does not enforce.
- Document the current reflection behavior in the README.

Current RisingWave 2.8.0 local validation shows `DECIMAL(10,2)` and `VARCHAR(12)` DDL are rejected, and bare `DECIMAL`/`NUMERIC` report unknown precision/scale. The precision/scale path is therefore covered with a helper-level test for future catalog support, while live reflection tests assert today's behavior.

## Validation

- `.venv/bin/pytest test/test_schema.py test/test_usage.py::UsageTest::test_type_compiler_strips_pg_length_and_precision_parameters -q` -> 13 passed
- `.venv/bin/pytest -q` -> 40 passed
- `git diff --check`
- `.venv/bin/flake8 sqlalchemy_risingwave/base.py test/test_schema.py`

Note: full-repo flake8 still has pre-existing failures in async psycopg test files unrelated to this change, so I linted the modified files directly.
